### PR TITLE
miku-grepのCLI自己説明、bundle smoke、MVP仕様テストを強化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 node_modules/
+.npm-cache/
 dist/
 bundle/
 coverage/

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 通常の `grep` の代わりに、検索結果、summary、diagnostics を JSON として返します。
 
-厳格な CLI / JSON 仕様は [docs/miku-grep-cli-spec.md](/Users/igapyon/Documents/git/miku-grep/docs/miku-grep-cli-spec.md) を参照してください。
+厳格な CLI / JSON 仕様は [docs/miku-grep-cli-spec.md](docs/miku-grep-cli-spec.md) を参照してください。
 
 ## 背景
 
@@ -22,7 +22,7 @@
 
 ## MVP
 
-MVP では次を扱います。
+現在の Node CLI MVP 実装では次を扱います。
 
 - Node CLI
 - stdin JSON 入力
@@ -36,6 +36,10 @@ MVP では次を扱います。
 - encoding rules
 - diagnostics
 - `detail` / `file-summary`
+- `--version`
+- `--help`
+
+`--help` は生成AI agent がそれだけを読んで request JSON を組み立てられるよう、stdin / stdout contract、request field、default、limit、result shape、diagnostic code、完全な stdin / stdout 例を含めています。
 
 ## CLI の基本形
 
@@ -58,6 +62,14 @@ runtime artifact の smoke test 用に、`--version` は stdin JSON なしで実
 ```bash
 miku-grep --version
 ```
+
+生成AI agent や automation がコマンド仕様を把握するために、`--help` も stdin JSON なしで実行できます。
+
+```bash
+miku-grep --help
+```
+
+`--help` は stdin / stdout contract、request field、default、limit、result shape、diagnostic code、完全な stdin / stdout 例、実行例を stdout に出力します。
 
 ## 最小 request 例
 
@@ -179,7 +191,7 @@ JavaScript 固有の regex flags は MVP では受け取りません。将来の
 
 ## 詳細仕様
 
-詳細は [miku-grep CLI Specification](/Users/igapyon/Documents/git/miku-grep/docs/miku-grep-cli-spec.md) にあります。
+詳細は [miku-grep CLI Specification](docs/miku-grep-cli-spec.md) にあります。
 
 主な内容:
 
@@ -193,6 +205,54 @@ JavaScript 固有の regex flags は MVP では受け取りません。将来の
 - default exclude preset
 - encoding policy
 - dangerous request handling
+
+## 開発
+
+依存関係を入れます。
+
+```bash
+npm install
+```
+
+テストを実行します。
+
+```bash
+npm test
+```
+
+`npm test` は TypeScript compile 後に Vitest を実行します。現状のテストは CLI contract、request validation、検索モード、encoding、diagnostics、sort、limit、bundle前提の subprocess実行をカバーしています。
+
+TypeScript compile、テスト、単一ファイル CLI bundle 生成をまとめて実行します。
+
+```bash
+npm run build
+```
+
+開発用 CLI の stdin / stdout smoke example を実行します。
+
+```bash
+npm run smoke
+```
+
+bundle 生成後に、単一ファイル runtime artifact の smoke test を実行します。
+
+```bash
+npm run smoke:bundle
+```
+
+主な生成物:
+
+- `dist/main.js`
+- `bundle/miku-grep.mjs`
+- `bundle/miku-grep-sources.tgz`
+
+`dist/main.js` は package `bin` が指す開発・npm package 用 CLI entry です。
+
+`bundle/miku-grep.mjs` は source tree なしで実行できる単一ファイル runtime artifact です。
+
+`bundle/miku-grep-sources.tgz` は再ビルド、監査、下流確認用の source archive です。
+
+npm package には、CLI実行用の `dist/`、単一ファイル runtime artifact の `bundle/`、smoke / bundle生成用の `scripts/`、`README.md`、`LICENSE` を含めます。
 
 ## 後続
 

--- a/TODO.md
+++ b/TODO.md
@@ -103,21 +103,22 @@
 
 - [x] validation implementation
   - 決定: MVP request validation は自前実装。
-  - TODO: 実装が肥大化した場合は JSON Schema 等の導入を再検討する。
+  - 現状: TypeScript 実装では `src/main.ts` の自前 validation で開始。
+  - TODO: 実装がさらに肥大化した場合は JSON Schema 等の導入を再検討する。
 
 - [x] Node module shape
   - 決定: 開発ソースは必要に応じて分割してよい。
   - 決定: 配布 runtime artifact は単一 `.mjs` (`bundle/miku-grep.mjs`) とする。
-  - TODO: package `bin` の正式なコマンド名と配置は実装時に決める。
+  - 実装: package `bin` は `miku-grep`、開発時 entry は `dist/main.js`、配布 runtime artifact は `bundle/miku-grep.mjs`。
 
 - [x] test runner
   - 決定: Vitest を候補として進める。
-  - TODO: 実装開始時に `package.json` と test script を確定する。
+  - 実装: `package.json` の `test` script は `vitest run`。
 
 - [x] Shift_JIS decoder
   - 決定: `iconv-lite` を使う。
   - 確認: npm の `iconv-lite` は MIT License。
-  - TODO: `package.json` に dependency として明記する。
+  - 実装: `package.json` の dependency に `iconv-lite` を明記。
 
 - [x] numeric safety limits
   - 決定: `search.maxDepth` の最大許容値は `50`。
@@ -149,3 +150,73 @@
   - 決定: exit code `2` / `3` でも、result JSON を安全に構築できる場合は stdout に返す。
   - 決定: malformed stdin、CLI usage error、unexpected runtime error などで result JSON を安全に構築できない場合は stderr-only を許容する。
   - 決定: caller は exit code を authoritative に扱う。
+
+## implementation follow-up
+
+- [x] README public path hygiene
+  - 実装: README の CLI specification link を repository-relative path に修正。
+
+- [x] package dry-run
+  - 確認: `npm_config_cache=.npm-cache npm pack --dry-run` で package contents を確認。
+  - 補足: default npm cache は local environment の権限問題で失敗したため、workspace-local cache を指定して確認した。
+
+- [x] CLI subprocess tests
+  - 実装: `dist/main.js` を subprocess として実行し、exit code / stdout JSON / stderr contract を確認。
+
+- [x] limit behavior tests
+  - 実装: `maxMatches` と `maxMatchesPerFile` 到達時の `summary` / `matches[]` / `diagnostics[]` をテストで固定。
+
+- [x] diagnostic code inventory
+  - validation / expected failure codes implemented:
+    - `invalid_request`
+    - `unknown_field`
+    - `invalid_version`
+    - `invalid_query_type`
+    - `invalid_search_target`
+    - `invalid_output_mode`
+    - `invalid_regex`
+    - `root_not_found`
+    - `root_not_accessible`
+    - `root_too_broad`
+    - `empty_query`
+    - `max_matches_too_large`
+    - `max_matches_per_file_too_large`
+    - `max_depth_too_large`
+    - `max_line_length_too_large`
+    - `max_snippets_per_file_too_large`
+    - `max_file_bytes_too_large`
+    - `invalid_encoding`
+    - `invalid_encoding_rule`
+  - runtime diagnostic codes implemented:
+    - `directory_not_readable`
+    - `symlink_skipped`
+    - `file_not_readable`
+    - `max_file_bytes_exceeded`
+    - `binary_file_skipped`
+    - `decode_error`
+    - `max_matches`
+    - `max_matches_per_file`
+    - `max_snippets_per_file`
+
+## later refactoring candidates
+
+まとめてリファクタリングする段階で検討する。
+
+- [ ] `helpText()` を `src/help.ts` に分離する
+  - 理由: AI agent 向けの自己説明が長く、CLI制御や検索実装と責務が異なる。
+
+- [ ] request validation を `src/validation.ts` に分離する
+  - 理由: validation code と effectiveRequest default展開が増えている。
+
+- [ ] traversal / file search を `src/search.ts` に分離する
+  - 理由: directory traversal、filename search、content search、limit処理を独立して読みやすくする。
+
+- [ ] glob / path matching を `src/glob.ts` または `src/path-utils.ts` に分離する
+  - 理由: include / exclude、encoding pathPattern、filename pattern の責務を明確にする。
+
+- [ ] diagnostics / summary helper を分離する
+  - 理由: diagnostic sorting、truncation diagnostic重複抑制、summary更新を局所化する。
+
+- [ ] tests を機能別に分割する
+  - 候補: `cli-meta.test.ts`、`validation.test.ts`、`search-content.test.ts`、`search-filename.test.ts`、`encoding.test.ts`、`bundle-smoke.test.ts`
+  - 理由: `test/miku-grep-cli.test.ts` がMVP仕様全体を保持して大きくなっている。

--- a/docs/miku-grep-cli-spec.md
+++ b/docs/miku-grep-cli-spec.md
@@ -59,15 +59,22 @@ stdout result JSON should be pretty-printed with 2-space indentation and a trail
 JSON.stringify(result, null, 2) + "\n"
 ```
 
-`--version` is an exception to the stdin request JSON contract.
+`--version` and `--help` are exceptions to the stdin request JSON contract.
 
 ```bash
 miku-grep --version
+miku-grep --help
 ```
 
-It prints a short version string to stdout and exits with code `0`.
+`--version` prints a short version string to stdout and exits with code `0`.
 
-This command exists so release assets and Agent Skills can smoke-test a runtime artifact without preparing a request JSON.
+`--help` prints a self-contained command description to stdout and exits with code `0`.
+The help output should be detailed enough for an AI agent to understand the
+stdin / stdout contract, request fields, defaults, limits, result shape,
+diagnostics, and examples without reading the full specification.
+
+These commands exist so release assets and Agent Skills can inspect or smoke-test
+a runtime artifact without preparing a request JSON.
 
 The bundled `.mjs` runtime artifact should embed the package version at build time, such as `BUNDLED_PACKAGE_VERSION`, and `--version` should use that embedded value when package metadata is unavailable.
 
@@ -780,12 +787,48 @@ Limit example:
 ```json
 {
   "severity": "info",
-  "code": "max_matches_reached",
+  "code": "max_matches",
   "message": "search stopped because maxMatches was reached",
   "details": {
     "maxMatches": 200
   }
 }
+```
+
+### Diagnostic Codes
+
+Validation and expected-failure diagnostic codes are listed in
+`Validation Error Codes`.
+
+MVP runtime diagnostic codes include:
+
+```text
+directory_not_readable
+  directory could not be read and was skipped
+
+symlink_skipped
+  symlink was skipped because MVP does not follow symlinks
+
+file_not_readable
+  file could not be read and was skipped
+
+max_file_bytes_exceeded
+  file exceeded search.maxFileBytes and was skipped
+
+binary_file_skipped
+  file was treated as binary and skipped during content search
+
+decode_error
+  file could not be decoded with the applied encoding rule and was skipped
+
+max_matches
+  search stopped because output.maxMatches was reached
+
+max_matches_per_file
+  search for a file stopped because output.maxMatchesPerFile was reached
+
+max_snippets_per_file
+  file-summary snippets were omitted because output.maxSnippetsPerFile was reached
 ```
 
 ## Summary
@@ -942,17 +985,30 @@ Recommended development shape:
 ```text
 package.json
 scripts/
-  miku-grep-cli.mjs
   build-cli-bundle.mjs
+  bundle-smoke.mjs
   stdio-example.mjs
-tests/
+src/
+  main.ts
+  types.ts
+  bundle-entry.ts
+test/
+  miku-grep-cli.test.ts
 workplace/
 ```
 
-Development source files may be split as needed. The distribution/runtime artifact should be a single `.mjs` file: `bundle/miku-grep.mjs`.
+Development source files may be split as needed. The current Node implementation uses `src/main.ts` as the CLI entry module, `src/types.ts` for public request/result types, and `src/bundle-entry.ts` as the single-file bundle entry.
+
+The npm package `bin` entry points to `dist/main.js`.
+
+The distribution/runtime artifact should be a single `.mjs` file: `bundle/miku-grep.mjs`.
+
+`bundle/miku-grep-sources.tgz` should contain enough source files for rebuild, audit, and downstream verification.
 
 Shift_JIS decoding should use `iconv-lite`. The package is MIT licensed and must be listed as a dependency when implementation begins.
 
 `scripts/stdio-example.mjs` or an equivalent smoke script should demonstrate stdin request JSON / stdout result JSON operation.
+
+`scripts/bundle-smoke.mjs` or an equivalent smoke script should verify the single-file runtime artifact, including `--version`, `--help`, stdin JSON execution, and source archive contents.
 
 Verbose and progress messages must go to stderr. stdout is reserved for result JSON except for explicit meta commands such as `--version`.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "cli": "node dist/main.js",
     "pack:check": "npm pack --dry-run",
     "smoke": "node scripts/stdio-example.mjs",
-    "test": "vitest run"
+    "smoke:bundle": "node scripts/bundle-smoke.mjs",
+    "test": "tsc -p tsconfig.json && vitest run"
   },
   "dependencies": {
     "iconv-lite": "^0.7.2"

--- a/scripts/build-cli-bundle.mjs
+++ b/scripts/build-cli-bundle.mjs
@@ -14,7 +14,7 @@ await build({
   platform: "node",
   format: "esm",
   banner: {
-    js: "#!/usr/bin/env node\nimport { createRequire } from 'node:module';\nconst require = createRequire(import.meta.url);"
+    js: "#!/usr/bin/env node\nimport { createRequire } from 'node:module';\nconst require = createRequire(import.meta.url);\nglobalThis.__MIKU_GREP_BUNDLE_ENTRY__ = true;"
   },
   define: {
     "globalThis.__MIKU_GREP_BUNDLED_PACKAGE_VERSION__": JSON.stringify(pkg.version)

--- a/scripts/bundle-smoke.mjs
+++ b/scripts/bundle-smoke.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process";
+
+const versionResult = spawnSync(process.execPath, ["bundle/miku-grep.mjs", "--version"], {
+  encoding: "utf8",
+});
+
+if (versionResult.status !== 0 || !versionResult.stdout.startsWith("miku-grep ")) {
+  process.stderr.write(versionResult.stderr || versionResult.stdout || "bundle --version smoke failed\n");
+  process.exit(1);
+}
+
+const helpResult = spawnSync(process.execPath, ["bundle/miku-grep.mjs", "--help"], {
+  encoding: "utf8",
+});
+if (
+  helpResult.status !== 0 ||
+  !helpResult.stdout.includes("REQUEST FIELDS") ||
+  !helpResult.stdout.includes("FULL STDIN / STDOUT EXAMPLE")
+) {
+  process.stderr.write(helpResult.stderr || helpResult.stdout || "bundle --help smoke failed\n");
+  process.exit(1);
+}
+
+const request = {
+  version: 1,
+  root: ".",
+  query: { type: "literal", text: "miku-grep" },
+  search: { target: "filename", recursive: true, maxDepth: 2 },
+  output: { mode: "file-summary", maxMatches: 10 },
+};
+const stdioResult = await runWithInput(process.execPath, ["bundle/miku-grep.mjs"], `${JSON.stringify(request)}\n`);
+
+if (stdioResult.code !== 0) {
+  process.stderr.write(stdioResult.stderr || stdioResult.stdout || "bundle stdio smoke failed\n");
+  process.exit(1);
+}
+
+const parsed = JSON.parse(stdioResult.stdout);
+if (parsed.version !== 1 || parsed.ok !== true || !Array.isArray(parsed.matches)) {
+  process.stderr.write("bundle stdio smoke returned unexpected JSON\n");
+  process.exit(1);
+}
+
+const archiveResult = spawnSync("tar", ["-tzf", "bundle/miku-grep-sources.tgz"], {
+  encoding: "utf8",
+});
+if (archiveResult.status !== 0) {
+  process.stderr.write(archiveResult.stderr || "source archive smoke failed\n");
+  process.exit(1);
+}
+const archiveEntries = new Set(archiveResult.stdout.trim().split("\n"));
+for (const entry of ["package.json", "src/main.ts", "src/types.ts", "test/miku-grep-cli.test.ts", "scripts/build-cli-bundle.mjs"]) {
+  if (!archiveEntries.has(entry)) {
+    process.stderr.write(`source archive missing ${entry}\n`);
+    process.exit(1);
+  }
+}
+
+process.stdout.write(versionResult.stdout);
+
+function runWithInput(command, args, input) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (code) => {
+      resolve({ code, stdout, stderr });
+    });
+    child.stdin.end(input);
+  });
+}

--- a/scripts/stdio-example.mjs
+++ b/scripts/stdio-example.mjs
@@ -5,7 +5,8 @@ const request = {
   version: 1,
   root: ".",
   query: { type: "literal", text: "miku-grep" },
-  search: { target: "both", recursive: true, maxDepth: 3 },
+  // Exclude local npm pack cache logs so smoke output stays repository-focused.
+  search: { target: "both", recursive: true, maxDepth: 3, excludeDirNamePatterns: [".npm-cache"] },
   output: { mode: "file-summary", maxMatches: 20 }
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,6 +102,7 @@ type SearchState = {
   detailsByFile: Map<string, DetailMatch[]>;
   summariesByFile: Map<string, FileSummaryMatch>;
   diagnostics: Diagnostic[];
+  truncationDiagnosticKeys: Set<string>;
   summary: Summary;
   globalLimitReached: boolean;
 };
@@ -112,8 +113,16 @@ export async function main(argv = process.argv, stdin = process.stdin, stdout = 
       stdout.write(`miku-grep ${await packageVersion()}\n`);
       return 0;
     }
+    if (argv.length === 3 && (argv[2] === "--help" || argv[2] === "-h")) {
+      stdout.write(helpText());
+      return 0;
+    }
+    if (argv.length === 3 && argv[2]?.startsWith("-")) {
+      stderr.write("usage: miku-grep [--version|--help]\n");
+      return 2;
+    }
     if (argv.length > 2) {
-      stderr.write("usage: miku-grep [--version]\n");
+      stderr.write("usage: miku-grep [--version|--help]\n");
       return 2;
     }
 
@@ -132,6 +141,236 @@ export async function main(argv = process.argv, stdin = process.stdin, stdout = 
     stderr.write(`unexpected runtime error: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
     return 3;
   }
+}
+
+export function helpText(): string {
+  return `miku-grep - local-first structured grep CLI for AI agents and automation
+
+USAGE
+  miku-grep < request.json > result.json
+  miku-grep --version
+  miku-grep --help
+
+CONTRACT
+  Primary input is stdin JSON. Primary output is stdout JSON.
+  stdout is reserved for result JSON except --version and --help.
+  stderr is for usage errors, malformed stdin, progress, verbose logs, and unexpected runtime messages.
+  Request JSON and result JSON use top-level "version": 1.
+  Unknown request fields are validation errors.
+  Result JSON is pretty-printed with 2-space indentation and a trailing newline.
+
+EXIT CODES
+  0  ok: true, or explicit meta command such as --version / --help
+  1  ok: false expected failure with stdout result JSON when possible
+  2  malformed stdin or CLI usage error
+  3  unexpected runtime error
+
+MINIMAL REQUEST
+  {
+    "version": 1,
+    "root": ".",
+    "query": { "type": "literal", "text": "RepositoryMap" },
+    "search": { "target": "content", "recursive": true, "maxDepth": 8 }
+  }
+
+REQUEST FIELDS
+  root
+    Search entry directory. Relative paths are resolved from current working directory.
+    Result file paths are root-relative and always use "/".
+
+  query.type
+    "literal" or "regex".
+    literal is case-sensitive substring search.
+    regex uses Node.js RegExp, line by line for content search. Regex flags are not accepted.
+
+  query.text
+    Non-empty search text or regex pattern.
+
+  search.target
+    "content" searches file contents.
+    "filename" searches root-relative file paths.
+    "both" searches filename first, then content.
+    Default: "content".
+
+  search.recursive
+    boolean. Default: true.
+
+  search.maxDepth
+    Default: 20 when recursive is true. Maximum: 50.
+
+  search.maxFileBytes
+    Content-read size limit. Default: 10485760. Maximum: 104857600.
+
+  search.includeFileNamePatterns
+    Optional glob array. Empty or missing means no include restriction.
+    MVP glob supports "*" and "?" within one basename.
+
+  search.excludeFileNamePatterns
+    Optional additional basename glob excludes.
+    Default excludes are always applied.
+
+  search.excludeDirNamePatterns
+    Optional additional directory basename glob excludes.
+    Default excludes are always applied.
+
+  output.mode
+    "file-summary" or "detail". Default: "file-summary".
+
+  output.maxMatches
+    Default: 200. Maximum: 10000.
+
+  output.maxMatchesPerFile
+    Default: 20. Maximum: 1000.
+
+  output.maxLineLength
+    Returned snippet limit. Default: 240. Maximum: 4000.
+    Snippets contain only source text. Artificial "..." is not added.
+
+  output.maxSnippetsPerFile
+    file-summary representative snippet limit. Default: 3. Maximum: 100.
+
+  encoding.default
+    "utf-8" or "shift_jis". Default: "utf-8".
+
+  encoding.rules
+    Array of { "pathPattern": "...", "encoding": "..." } or
+    { "fileNamePattern": "...", "encoding": "..." }.
+    pathPattern rules take priority over fileNamePattern rules.
+
+  encoding.onDecodeError
+    "skip". Decode failures are reported in diagnostics.
+
+DEFAULT EXCLUDES
+  Directory names:
+    .git, .svn, node_modules, target, build, dist, .gradle, .idea, .vscode, .settings, vendor
+  File name patterns:
+    *.class, *.jar, *.zip, *.png, *.jpg, *.jpeg, *.gif, *.pdf, .classpath, .project
+
+RESULT SHAPE
+  {
+    "version": 1,
+    "ok": true,
+    "error": null,
+    "effectiveRequest": {},
+    "matches": [],
+    "summary": {
+      "filesVisited": 0,
+      "filesScanned": 0,
+      "filesMatched": 0,
+      "matches": 0,
+      "diagnostics": 0,
+      "truncated": false,
+      "truncatedReason": null
+    },
+    "diagnostics": []
+  }
+
+FULL STDIN / STDOUT EXAMPLE
+  Input:
+    {
+      "version": 1,
+      "root": ".",
+      "query": { "type": "literal", "text": "RepositoryMap" },
+      "search": {
+        "target": "content",
+        "recursive": true,
+        "maxDepth": 8,
+        "includeFileNamePatterns": ["*.java", "*.md"]
+      },
+      "output": { "mode": "file-summary", "maxMatches": 20 }
+    }
+
+  Possible successful output:
+    {
+      "version": 1,
+      "ok": true,
+      "error": null,
+      "effectiveRequest": {
+        "root": ".",
+        "query": { "type": "literal", "text": "RepositoryMap" },
+        "search": {
+          "target": "content",
+          "recursive": true,
+          "maxDepth": 8,
+          "maxFileBytes": 10485760,
+          "includeFileNamePatterns": ["*.java", "*.md"],
+          "excludeFileNamePatterns": ["*.class", "*.jar", "*.zip", "*.png", "*.jpg", "*.jpeg", "*.gif", "*.pdf", ".classpath", ".project"],
+          "excludeDirNamePatterns": [".git", ".svn", "node_modules", "target", "build", "dist", ".gradle", ".idea", ".vscode", ".settings", "vendor"]
+        },
+        "output": { "mode": "file-summary", "maxMatches": 20, "maxMatchesPerFile": 20, "maxLineLength": 240, "maxSnippetsPerFile": 3 },
+        "encoding": { "default": "utf-8", "rules": [], "onDecodeError": "skip" }
+      },
+      "matches": [
+        {
+          "type": "file",
+          "file": "src/RepositoryMap.java",
+          "matchTypes": ["content"],
+          "filenameMatched": false,
+          "contentMatched": true,
+          "lines": [42],
+          "matchCount": 1,
+          "snippets": [
+            { "type": "content", "line": 42, "text": "class RepositoryMap {", "trimmed": false }
+          ],
+          "encoding": "utf-8",
+          "encodingRule": { "type": "default" }
+        }
+      ],
+      "summary": { "filesVisited": 12, "filesScanned": 10, "filesMatched": 1, "matches": 1, "diagnostics": 0, "truncated": false, "truncatedReason": null },
+      "diagnostics": []
+    }
+
+  Possible validation error output:
+    {
+      "version": 1,
+      "ok": false,
+      "error": { "code": "empty_query", "message": "query.text must not be empty" },
+      "effectiveRequest": {},
+      "matches": [],
+      "summary": { "filesVisited": 0, "filesScanned": 0, "filesMatched": 0, "matches": 0, "diagnostics": 1, "truncated": false, "truncatedReason": null },
+      "diagnostics": [
+        { "severity": "error", "code": "empty_query", "message": "query.text must not be empty" }
+      ]
+    }
+
+DETAIL MATCHES
+  Content hit:
+    { "type": "content", "file": "src/App.java", "line": 42, "column": 7,
+      "matchedText": "RepositoryMap", "text": "class RepositoryMap {",
+      "trimmed": false, "encoding": "utf-8", "encodingRule": { "type": "default" } }
+  Filename hit:
+    { "type": "filename", "file": "src/RepositoryMap.java",
+      "matchedText": "src/RepositoryMap.java" }
+
+FILE-SUMMARY MATCHES
+  { "type": "file", "file": "src/RepositoryMap.java",
+    "matchTypes": ["filename", "content"],
+    "filenameMatched": true, "contentMatched": true,
+    "lines": [42], "matchCount": 1, "snippets": [] }
+
+COMMON DIAGNOSTIC CODES
+  Validation / expected failures:
+    invalid_request, unknown_field, invalid_version, invalid_query_type,
+    invalid_search_target, invalid_output_mode, invalid_regex,
+    root_not_found, root_not_accessible, root_too_broad, empty_query,
+    max_matches_too_large, max_matches_per_file_too_large, max_depth_too_large,
+    max_line_length_too_large, max_snippets_per_file_too_large,
+    max_file_bytes_too_large, invalid_encoding, invalid_encoding_rule
+  Runtime diagnostics:
+    directory_not_readable, symlink_skipped, file_not_readable,
+    max_file_bytes_exceeded, binary_file_skipped, decode_error,
+    max_matches, max_matches_per_file, max_snippets_per_file
+
+EXAMPLES
+  Content search:
+    printf '%s\\n' '{"version":1,"root":".","query":{"type":"literal","text":"TODO"},"search":{"target":"content"}}' | miku-grep
+
+  Filename search:
+    printf '%s\\n' '{"version":1,"root":".","query":{"type":"regex","text":"Repository.*\\\\.java$"},"search":{"target":"filename"},"output":{"mode":"detail"}}' | miku-grep
+
+SEE ALSO
+  docs/miku-grep-cli-spec.md
+`;
 }
 
 export async function runRequest(request: unknown): Promise<MikuGrepResult> {
@@ -163,6 +402,7 @@ export async function runRequest(request: unknown): Promise<MikuGrepResult> {
     detailsByFile: new Map(),
     summariesByFile: new Map(),
     diagnostics,
+    truncationDiagnosticKeys: new Set(),
     summary: createSummary(),
     globalLimitReached: false,
   };
@@ -519,6 +759,9 @@ function markTruncated(state: SearchState, reason: string, message: string, deta
     state.summary.truncated = true;
     state.summary.truncatedReason = reason;
   }
+  const diagnosticKey = `${reason}:${JSON.stringify(details)}`;
+  if (state.truncationDiagnosticKeys.has(diagnosticKey)) return;
+  state.truncationDiagnosticKeys.add(diagnosticKey);
   state.diagnostics.push({ severity: "info", code: reason, message, details });
 }
 
@@ -668,6 +911,10 @@ function isNodeError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && "code" in error;
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href &&
+  !(globalThis as typeof globalThis & { __MIKU_GREP_BUNDLE_ENTRY__?: boolean }).__MIKU_GREP_BUNDLE_ENTRY__
+) {
   process.exitCode = await main();
 }

--- a/test/miku-grep-cli.test.ts
+++ b/test/miku-grep-cli.test.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { Readable } from "node:stream";
 import { describe, expect, test } from "vitest";
 import iconv from "iconv-lite";
-import { runRequest } from "../src/main.js";
+import { helpText, main, runRequest } from "../src/main.js";
 
 async function fixture(): Promise<string> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
@@ -16,7 +18,56 @@ async function fixture(): Promise<string> {
   return root;
 }
 
+function writableCapture(): { stream: NodeJS.WritableStream; output: () => string } {
+  const chunks: string[] = [];
+  return {
+    stream: {
+      write(chunk: string | Uint8Array): boolean {
+        chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+        return true;
+      },
+    } as NodeJS.WritableStream,
+    output: () => chunks.join(""),
+  };
+}
+
+function baseRequest(root: string): Record<string, unknown> {
+  return {
+    version: 1,
+    root,
+    query: { type: "literal", text: "RepositoryMap" },
+  };
+}
+
 describe("miku-grep CLI request runner", () => {
+  test("help text explains enough for agents to construct requests", () => {
+    const text = helpText();
+
+    expect(text).toContain("USAGE");
+    expect(text).toContain("MINIMAL REQUEST");
+    expect(text).toContain("REQUEST FIELDS");
+    expect(text).toContain("RESULT SHAPE");
+    expect(text).toContain("FULL STDIN / STDOUT EXAMPLE");
+    expect(text).toContain("Possible successful output");
+    expect(text).toContain("Possible validation error output");
+    expect(text).toContain("COMMON DIAGNOSTIC CODES");
+    expect(text).toContain('"version": 1');
+    expect(text).toContain("search.target");
+    expect(text).toContain("output.mode");
+    expect(text).toContain("encoding.rules");
+  });
+
+  test("main returns exit 0 and stdout help for --help without reading stdin", async () => {
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(["node", "miku-grep", "--help"], Readable.from([]), stdout.stream, stderr.stream);
+
+    expect(code).toBe(0);
+    expect(stderr.output()).toBe("");
+    expect(stdout.output()).toContain("miku-grep - local-first structured grep CLI");
+    expect(stdout.output()).toContain("MINIMAL REQUEST");
+  });
+
   test("returns file-summary matches with defaults and excludes node_modules", async () => {
     const root = await fixture();
     const result = await runRequest({
@@ -34,6 +85,56 @@ describe("miku-grep CLI request runner", () => {
     expect(result.summary.matches).toBe(3);
   });
 
+  test("expands effectiveRequest defaults with stable key order", async () => {
+    const root = await fixture();
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(Object.keys(result.effectiveRequest)).toEqual(["root", "query", "search", "output", "encoding"]);
+    expect(Object.keys(result.effectiveRequest.search)).toEqual([
+      "target",
+      "recursive",
+      "maxDepth",
+      "maxFileBytes",
+      "includeFileNamePatterns",
+      "excludeFileNamePatterns",
+      "excludeDirNamePatterns",
+    ]);
+    expect(Object.keys(result.effectiveRequest.output)).toEqual([
+      "mode",
+      "maxMatches",
+      "maxMatchesPerFile",
+      "maxLineLength",
+      "maxSnippetsPerFile",
+    ]);
+    expect(Object.keys(result.effectiveRequest.encoding)).toEqual(["default", "rules", "onDecodeError"]);
+    expect(result.effectiveRequest.search).toMatchObject({
+      target: "content",
+      recursive: true,
+      maxDepth: 20,
+      maxFileBytes: 10485760,
+      includeFileNamePatterns: [],
+    });
+    expect(result.effectiveRequest.search.excludeFileNamePatterns).toEqual(
+      expect.arrayContaining(["*.class", "*.jar", "*.zip", "*.png", "*.jpg", "*.jpeg", "*.gif", "*.pdf", ".classpath", ".project"]),
+    );
+    expect(result.effectiveRequest.search.excludeDirNamePatterns).toEqual(
+      expect.arrayContaining([".git", ".svn", "node_modules", "target", "build", "dist", ".gradle", ".idea", ".vscode", ".settings", "vendor"]),
+    );
+    expect(result.effectiveRequest.output).toEqual({
+      mode: "file-summary",
+      maxMatches: 200,
+      maxMatchesPerFile: 20,
+      maxLineLength: 240,
+      maxSnippetsPerFile: 3,
+    });
+    expect(result.effectiveRequest.encoding).toEqual({ default: "utf-8", rules: [], onDecodeError: "skip" });
+  });
+
   test("returns detail filename hits before content hits for both target", async () => {
     const root = await fixture();
     const result = await runRequest({
@@ -49,6 +150,97 @@ describe("miku-grep CLI request runner", () => {
     expect(javaHits[0]?.type).toBe("filename");
     expect(javaHits[1]?.type).toBe("content");
     expect(javaHits[1]).toMatchObject({ line: 1, column: 7 });
+  });
+
+  test("sorts detail matches by file path and then filename before content hits", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "b-RepositoryMap.txt"), "RepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "a-RepositoryMap.txt"), "x\nRepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "both" },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([
+      { type: "filename", file: "a-RepositoryMap.txt", matchedText: "RepositoryMap" },
+      expect.objectContaining({ type: "content", file: "a-RepositoryMap.txt", line: 2, column: 1 }),
+      { type: "filename", file: "b-RepositoryMap.txt", matchedText: "RepositoryMap" },
+      expect.objectContaining({ type: "content", file: "b-RepositoryMap.txt", line: 1, column: 1 }),
+    ]);
+  });
+
+  test("aggregates filename and content hits in file-summary mode", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "src"), { recursive: true });
+    await fs.writeFile(path.join(root, "src", "RepositoryMap.java"), "class RepositoryMap {\n  RepositoryMap field;\n}\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "both" },
+      output: { mode: "file-summary", maxSnippetsPerFile: 1 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([
+      expect.objectContaining({
+        type: "file",
+        file: "src/RepositoryMap.java",
+        matchTypes: ["filename", "content"],
+        filenameMatched: true,
+        contentMatched: true,
+        lines: [1, 2],
+        matchCount: 3,
+        snippets: [{ type: "content", line: 1, text: "class RepositoryMap {", trimmed: false }],
+        encoding: "utf-8",
+        encodingRule: { type: "default" },
+      }),
+    ]);
+    expect(result.summary.matches).toBe(3);
+    expect(result.summary.filesMatched).toBe(1);
+  });
+
+  test("regex content search is line-based and returns multiple hits", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "regex.txt"), "RepositoryMap RepositoryMap\nRepository\nMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "RepositoryMap" },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toHaveLength(2);
+    expect(result.matches).toEqual([
+      expect.objectContaining({ file: "regex.txt", line: 1, column: 1, matchedText: "RepositoryMap" }),
+      expect.objectContaining({ file: "regex.txt", line: 1, column: 15, matchedText: "RepositoryMap" }),
+    ]);
+  });
+
+  test("regex search handles zero-length matches without hanging", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "zero.txt"), "ab\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "(?=a)|(?=b)" },
+      output: { mode: "detail", maxMatchesPerFile: 10 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([
+      expect.objectContaining({ file: "zero.txt", line: 1, column: 1, matchedText: "" }),
+      expect.objectContaining({ file: "zero.txt", line: 1, column: 2, matchedText: "" }),
+    ]);
   });
 
   test("applies shift_jis encoding rules", async () => {
@@ -86,5 +278,569 @@ describe("miku-grep CLI request runner", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error?.code).toBe("unknown_field");
+  });
+
+  test.each([
+    ["non-object request", null, "invalid_request"],
+    ["non-object search", (root: string) => ({ ...baseRequest(root), search: [] }), "invalid_request"],
+    ["non-object output", (root: string) => ({ ...baseRequest(root), output: [] }), "invalid_request"],
+    ["non-object encoding", (root: string) => ({ ...baseRequest(root), encoding: [] }), "invalid_request"],
+    ["non-string include pattern", (root: string) => ({ ...baseRequest(root), search: { includeFileNamePatterns: ["*.txt", 1] } }), "invalid_request"],
+    ["non-string exclude file pattern", (root: string) => ({ ...baseRequest(root), search: { excludeFileNamePatterns: [false] } }), "invalid_request"],
+    ["non-string exclude dir pattern", (root: string) => ({ ...baseRequest(root), search: { excludeDirNamePatterns: [{}] } }), "invalid_request"],
+    ["unknown encoding rule field", (root: string) => ({ ...baseRequest(root), encoding: { rules: [{ fileNamePattern: "*.txt", encoding: "utf-8", extra: true }] } }), "unknown_field"],
+  ])("rejects invalid request shape: %s", async (_caseName, createRequest, expectedCode) => {
+    const root = await fixture();
+    const request = typeof createRequest === "function" ? createRequest(root) : createRequest;
+    const result = await runRequest(request);
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe(expectedCode);
+  });
+
+  test("rejects dangerous broad roots", async () => {
+    const result = await runRequest({
+      version: 1,
+      root: path.parse(process.cwd()).root,
+      query: { type: "literal", text: "RepositoryMap" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("root_too_broad");
+    expect(result.diagnostics[0]).toMatchObject({ severity: "error", code: "root_too_broad" });
+  });
+
+  test("returns root_not_accessible when root is a file", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    const fileRoot = path.join(root, "not-dir.txt");
+    await fs.writeFile(fileRoot, "RepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root: fileRoot,
+      query: { type: "literal", text: "RepositoryMap" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("root_not_accessible");
+    expect(result.diagnostics[0]).toMatchObject({ severity: "error", code: "root_not_accessible" });
+  });
+
+  test("rejects invalid regex and numeric limits", async () => {
+    const root = await fixture();
+    const invalidRegex = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "[" },
+    });
+    const tooManyMatches = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      output: { maxMatches: 10001 },
+    });
+
+    expect(invalidRegex.ok).toBe(false);
+    expect(invalidRegex.error?.code).toBe("invalid_regex");
+    expect(tooManyMatches.ok).toBe(false);
+    expect(tooManyMatches.error?.code).toBe("max_matches_too_large");
+  });
+
+  test.each([
+    ["invalid_version", (root: string) => ({ ...baseRequest(root), version: 2 })],
+    ["invalid_query_type", (root: string) => ({ ...baseRequest(root), query: { type: "glob", text: "RepositoryMap" } })],
+    ["invalid_search_target", (root: string) => ({ ...baseRequest(root), search: { target: "path" } })],
+    ["invalid_output_mode", (root: string) => ({ ...baseRequest(root), output: { mode: "raw" } })],
+    ["max_depth_too_large", (root: string) => ({ ...baseRequest(root), search: { maxDepth: 51 } })],
+    ["max_line_length_too_large", (root: string) => ({ ...baseRequest(root), output: { maxLineLength: 4001 } })],
+    ["max_snippets_per_file_too_large", (root: string) => ({ ...baseRequest(root), output: { maxSnippetsPerFile: 101 } })],
+    ["max_file_bytes_too_large", (root: string) => ({ ...baseRequest(root), search: { maxFileBytes: 104857601 } })],
+    ["invalid_encoding", (root: string) => ({ ...baseRequest(root), encoding: { default: "euc-jp" } })],
+    ["invalid_encoding_rule", (root: string) => ({ ...baseRequest(root), encoding: { rules: [{ fileNamePattern: "*.txt", encoding: "euc-jp" }] } })],
+  ])("rejects requests with %s", async (expectedCode, createRequest) => {
+    const root = await fixture();
+    const result = await runRequest(createRequest(root));
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe(expectedCode);
+    expect(result.diagnostics[0]).toMatchObject({ severity: "error", code: expectedCode });
+  });
+
+  test("reports maxFileBytes and NUL binary skips as diagnostics", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "big.txt"), "RepositoryMap\n");
+    await fs.writeFile(path.join(root, "nul.bin"), Buffer.from([82, 0, 82]));
+
+    const sizeLimited = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "content", maxFileBytes: 1 },
+    });
+    const binarySkipped = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "R" },
+      search: { target: "content" },
+    });
+
+    expect(sizeLimited.ok).toBe(true);
+    expect(sizeLimited.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "max_file_bytes_exceeded", file: "big.txt", skipped: true })]),
+    );
+    expect(binarySkipped.ok).toBe(true);
+    expect(binarySkipped.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "binary_file_skipped", file: "nul.bin", skipped: true })]),
+    );
+  });
+
+  test("default binary-like file patterns are excluded before content scanning", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "image.png"), "RepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "archive.zip"), "RepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "plain.txt"), "RepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "content" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches.map((match) => match.file)).toEqual(["plain.txt"]);
+    expect(result.summary.filesVisited).toBe(3);
+    expect(result.summary.filesScanned).toBe(1);
+    expect(result.diagnostics).toEqual([]);
+  });
+
+  test("reports skipped symlinks without following them", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "target.txt"), "RepositoryMap\n", "utf8");
+    await fs.symlink(path.join(root, "target.txt"), path.join(root, "link.txt"));
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "content" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches.map((match) => match.file)).toEqual(["target.txt"]);
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ severity: "info", code: "symlink_skipped", path: "link.txt", skipped: true })]),
+    );
+  });
+
+  test("applies include and exclude file name patterns by basename", async () => {
+    const root = await fixture();
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: {
+        target: "content",
+        includeFileNamePatterns: ["*.java", "*.md"],
+        excludeFileNamePatterns: ["README.md"],
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches.map((match) => match.file)).toEqual(["src/RepositoryMap.java"]);
+    expect(result.effectiveRequest.search.excludeFileNamePatterns).toContain("README.md");
+  });
+
+  test("filename search matches root-relative paths while include patterns match basenames", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "src"), { recursive: true });
+    await fs.writeFile(path.join(root, "src", "App.java"), "no content hit\n", "utf8");
+    await fs.writeFile(path.join(root, "App.java"), "no content hit\n", "utf8");
+
+    const pathMatch = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "src/App.java" },
+      search: { target: "filename", includeFileNamePatterns: ["App.java"] },
+      output: { mode: "detail" },
+    });
+    const includeDoesNotMatchPath = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "App.java" },
+      search: { target: "filename", includeFileNamePatterns: ["src/App.java"] },
+      output: { mode: "detail" },
+    });
+
+    expect(pathMatch.ok).toBe(true);
+    expect(pathMatch.matches).toEqual([
+      { type: "filename", file: "src/App.java", matchedText: "src/App.java" },
+    ]);
+    expect(includeDoesNotMatchPath.ok).toBe(true);
+    expect(includeDoesNotMatchPath.matches).toEqual([]);
+    expect(includeDoesNotMatchPath.summary.filesScanned).toBe(0);
+  });
+
+  test("filename-only search does not read undecodable file contents", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "bad-name.txt"), Buffer.from([0xff, 0xfe, 0xfd]));
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "bad-name" },
+      search: { target: "filename" },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([{ type: "filename", file: "bad-name.txt", matchedText: "bad-name" }]);
+    expect(result.diagnostics).toEqual([]);
+    expect(result.summary.filesScanned).toBe(1);
+  });
+
+  test("both search reports filename hits and content diagnostics", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "RepositoryMap-bad.txt"), Buffer.from([0xff, 0xfe, 0xfd]));
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "both" },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([{ type: "filename", file: "RepositoryMap-bad.txt", matchedText: "RepositoryMap" }]);
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "decode_error", file: "RepositoryMap-bad.txt", skipped: true })]),
+    );
+  });
+
+  test("applies exclude directory patterns and non-recursive traversal", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "keep"), { recursive: true });
+    await fs.mkdir(path.join(root, "skip"), { recursive: true });
+    await fs.writeFile(path.join(root, "root.txt"), "RepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "keep", "keep.txt"), "RepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "skip", "skip.txt"), "RepositoryMap\n", "utf8");
+
+    const excludedDir = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "content", excludeDirNamePatterns: ["skip"] },
+    });
+    const nonRecursive = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "content", recursive: false },
+    });
+
+    expect(excludedDir.ok).toBe(true);
+    expect(excludedDir.matches.map((match) => match.file)).toEqual(["keep/keep.txt", "root.txt"]);
+    expect(nonRecursive.ok).toBe(true);
+    expect(nonRecursive.matches.map((match) => match.file)).toEqual(["root.txt"]);
+    expect(nonRecursive.effectiveRequest.search.maxDepth).toBe(0);
+  });
+
+  test("applies maxDepth to recursive traversal", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "a", "b"), { recursive: true });
+    await fs.writeFile(path.join(root, "root.txt"), "RepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "a", "one.txt"), "RepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "a", "b", "two.txt"), "RepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "content", recursive: true, maxDepth: 1 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches.map((match) => match.file)).toEqual(["a/one.txt", "root.txt"]);
+  });
+
+  test("trims snippets around matches without artificial ellipses", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "long.txt"), `${"a".repeat(20)}RepositoryMap${"z".repeat(20)}\n`, "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      output: { mode: "detail", maxLineLength: 20 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches[0]).toMatchObject({
+      type: "content",
+      trimmed: true,
+      textStartColumn: 17,
+      text: "aaaaRepositoryMapzzz",
+    });
+    expect("text" in result.matches[0] ? result.matches[0].text : "").not.toContain("...");
+  });
+
+  test("omits textStartColumn when a trimmed snippet starts at the first column", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "prefix.txt"), `RepositoryMap${"z".repeat(40)}\n`, "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      output: { mode: "detail", maxLineLength: 20 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches[0]).toMatchObject({
+      type: "content",
+      trimmed: true,
+      text: "RepositoryMapzzzzzzz",
+    });
+    expect(result.matches[0]).not.toHaveProperty("textStartColumn");
+  });
+
+  test("normalizes LF, CRLF, and CR line endings for line numbers", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "lines.txt"), "one\nRepositoryMap\r\nthree\rRepositoryMap", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([
+      expect.objectContaining({ file: "lines.txt", line: 2, column: 1 }),
+      expect.objectContaining({ file: "lines.txt", line: 4, column: 1 }),
+    ]);
+  });
+
+  test("reports decode errors and strips UTF-8 BOM before matching", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "bad.txt"), Buffer.from([0xff, 0xfe, 0xfd]));
+    await fs.writeFile(path.join(root, "bom.txt"), Buffer.concat([Buffer.from([0xef, 0xbb, 0xbf]), Buffer.from("RepositoryMap\n", "utf8")]));
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([
+      expect.objectContaining({ file: "bom.txt", line: 1, column: 1, matchedText: "RepositoryMap" }),
+    ]);
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "decode_error", file: "bad.txt", skipped: true })]),
+    );
+  });
+
+  test("sorts diagnostics by path or file and then code", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "z-bad.txt"), Buffer.from([0xff, 0xfe, 0xfd]));
+    await fs.writeFile(path.join(root, "target.txt"), "RepositoryMap\n", "utf8");
+    await fs.symlink(path.join(root, "target.txt"), path.join(root, "a-link.txt"));
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.file ?? diagnostic.path)).toEqual(["a-link.txt", "z-bad.txt"]);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(["symlink_skipped", "decode_error"]);
+  });
+
+  test("returns root_not_found for missing roots", async () => {
+    const root = path.join(os.tmpdir(), `miku-grep-missing-${Date.now()}-${Math.random()}`);
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error?.code).toBe("root_not_found");
+    expect(result.diagnostics[0]).toMatchObject({ severity: "error", code: "root_not_found" });
+  });
+
+  test("gives pathPattern encoding rules priority over fileNamePattern rules", async () => {
+    const root = await fixture();
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "こんにちは" },
+      search: { target: "content", recursive: true },
+      output: { mode: "detail" },
+      encoding: {
+        default: "utf-8",
+        rules: [
+          { pathPattern: "src/legacy.txt", encoding: "shift_jis" },
+          { fileNamePattern: "legacy.txt", encoding: "utf-8" },
+        ],
+        onDecodeError: "skip",
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches[0]).toMatchObject({
+      file: "src/legacy.txt",
+      encodingRule: { type: "pathPattern", pattern: "src/legacy.txt" },
+    });
+  });
+
+  test("emits maxSnippetsPerFile diagnostics once per file", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "many.txt"), "RepositoryMap\nRepositoryMap\nRepositoryMap\nRepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      output: { mode: "file-summary", maxSnippetsPerFile: 1 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary.truncatedReason).toBe("max_snippets_per_file");
+    expect(result.diagnostics.filter((diagnostic) => diagnostic.code === "max_snippets_per_file")).toHaveLength(1);
+  });
+
+  test("stops at maxMatches with consistent summary and diagnostics", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "a.txt"), "RepositoryMap\nRepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "b.txt"), "RepositoryMap\nRepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      output: { mode: "detail", maxMatches: 2 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toHaveLength(2);
+    expect(result.summary.matches).toBe(2);
+    expect(result.summary.truncated).toBe(true);
+    expect(result.summary.truncatedReason).toBe("max_matches");
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "max_matches", details: { maxMatches: 2 } })]),
+    );
+  });
+
+  test("stops each file at maxMatchesPerFile while continuing traversal", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "a.txt"), "RepositoryMap\nRepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "b.txt"), "RepositoryMap\nRepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      output: { mode: "detail", maxMatchesPerFile: 1 },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches.map((match) => match.file)).toEqual(["a.txt", "b.txt"]);
+    expect(result.summary.matches).toBe(2);
+    expect(result.summary.filesMatched).toBe(2);
+    expect(result.summary.truncated).toBe(true);
+    expect(result.summary.truncatedReason).toBe("max_matches_per_file");
+    expect(result.diagnostics.filter((diagnostic) => diagnostic.code === "max_matches_per_file")).toHaveLength(2);
+  });
+
+  test("main returns exit 0 and stdout JSON for valid requests", async () => {
+    const root = await fixture();
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(
+      ["node", "miku-grep"],
+      Readable.from([
+        JSON.stringify({
+          version: 1,
+          root,
+          query: { type: "literal", text: "RepositoryMap" },
+          search: { target: "filename" },
+        }),
+      ]),
+      stdout.stream,
+      stderr.stream,
+    );
+
+    expect(code).toBe(0);
+    expect(stderr.output()).toBe("");
+    expect(JSON.parse(stdout.output())).toMatchObject({ version: 1, ok: true });
+  });
+
+  test("main returns exit 1 and stdout JSON for validation errors", async () => {
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(
+      ["node", "miku-grep"],
+      Readable.from([JSON.stringify({ version: 1, root: ".", query: { type: "literal", text: "" } })]),
+      stdout.stream,
+      stderr.stream,
+    );
+
+    expect(code).toBe(1);
+    expect(stderr.output()).toBe("");
+    expect(JSON.parse(stdout.output())).toMatchObject({ ok: false, error: { code: "empty_query" } });
+  });
+
+  test("main returns exit 2 and stderr-only for malformed stdin", async () => {
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(["node", "miku-grep"], Readable.from(["{"]), stdout.stream, stderr.stream);
+
+    expect(code).toBe(2);
+    expect(stdout.output()).toBe("");
+    expect(stderr.output()).toContain("malformed stdin:");
+  });
+
+  test("main returns exit 2 and stderr-only for unknown options", async () => {
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(["node", "miku-grep", "--unknown"], Readable.from([]), stdout.stream, stderr.stream);
+
+    expect(code).toBe(2);
+    expect(stdout.output()).toBe("");
+    expect(stderr.output()).toContain("usage: miku-grep [--version|--help]");
+  });
+
+  test("dist CLI process returns exit 0 with parseable stdout JSON", async () => {
+    const root = await fixture();
+    const result = spawnSync(process.execPath, ["dist/main.js"], {
+      input: `${JSON.stringify({
+        version: 1,
+        root,
+        query: { type: "literal", text: "RepositoryMap" },
+        search: { target: "filename" },
+      })}\n`,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({ ok: true, version: 1 });
+  });
+
+  test("dist CLI process returns exit 1 with stdout JSON for validation errors", () => {
+    const result = spawnSync(process.execPath, ["dist/main.js"], {
+      input: `${JSON.stringify({ version: 1, root: ".", query: { type: "literal", text: "" } })}\n`,
+      encoding: "utf8",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toBe("");
+    expect(JSON.parse(result.stdout)).toMatchObject({ ok: false, error: { code: "empty_query" } });
   });
 });


### PR DESCRIPTION
## 概要

`miku-grep` のNode CLI MVPについて、AI agentが利用しやすい `--help` 出力、bundle smoke、仕様追従テスト、README/spec/TODOの整備を追加します。

## 変更内容

- `--help` を追加
  - stdinなしで実行可能
  - stdin / stdout contract、request fields、default、limit、result shape、diagnostic code、完全なstdin/stdout例を出力
  - unknown optionはusage errorとして扱う

- bundle smokeを追加
  - `scripts/bundle-smoke.mjs` を追加
  - bundleの `--version`
  - bundleの `--help`
  - stdin JSON実行
  - source archive contents確認

- テストを強化
  - request validation
  - `effectiveRequest` default展開とkey順
  - `content` / `filename` / `both`
  - literal / regex
  - encoding / decode error / BOM
  - diagnostics / sort / limit
  - symlink skip
  - snippet trim
  - subprocess CLI実行
  - root境界条件

- ドキュメントを更新
  - READMEの絶対パスリンクを相対リンクへ修正
  - READMEに開発手順、生成物、package contents、`--help`説明を追加
  - CLI specに `--help`、runtime diagnostic code、現行の開発構成を反映
  - TODOに実装済み事項、diagnostic code棚卸し、後続リファクタリング候補を追加

- package / scriptsを更新
  - `smoke:bundle` scriptを追加
  - `npm test` を TypeScript compile + Vitest 実行に変更
  - `.npm-cache/` をgitignoreに追加
  - stdio smokeで `.npm-cache` を除外

## 確認

このコミットでは以下の確認用コマンドが整備されています。

- `npm test`
- `npm run build`
- `npm run smoke`
- `npm run smoke:bundle`
- `npm pack --dry-run`

## 補足

`TODO.md` に、後続でまとめて実施するリファクタリング候補を記録しています。