### PR TITLE
検索リソース制限とセキュリティ検証を強化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 厳格な CLI / JSON 仕様は [docs/miku-grep-cli-spec.md](docs/miku-grep-cli-spec.md) を参照してください。
 
+セキュリティに関する調査結果と対策は [docs/miku-grep-security.md](docs/miku-grep-security.md) を参照してください。
+
 ## 背景
 
 生成AI agent と repository を扱っていると、通常の grep だけでは足りない場面があります。
@@ -144,6 +146,8 @@ both
 
 `request.root` が相対パスの場合、CLI process の current working directory から解決します。
 
+探索中に realpath が `request.root` の realpath 外へ解決される path は skip して diagnostics に返します。
+
 result JSON 内の `file` は `request.root` からの相対パスです。絶対パスは返しません。path separator は platform に関わらず常に `/` です。
 
 `recursive: true` で `maxDepth` を省略した場合、MVP では `20` として扱います。
@@ -151,6 +155,8 @@ result JSON 内の `file` は `request.root` からの相対パスです。絶�
 `maxDepth` の最大許容値は `50` です。
 
 `recursive` 未指定時は `true` です。
+
+traversal の resource limit として、`search.maxFilesVisited` の default は `100000`、最大許容値は `1000000` です。`search.maxDirectoriesVisited` の default は `10000`、最大許容値は `100000` です。
 
 ## 除外の基本方針
 
@@ -177,6 +183,8 @@ content 検索では `search.maxFileBytes` の default を 10 MiB とし、超�
 
 `search.maxFileBytes` の最大許容値は 100 MiB です。
 
+decode 後の 1 行が `search.maxLineChars` を超える場合、その行は skip して diagnostics に返します。default は `1000000`、最大許容値は `10000000` です。
+
 ## regex と case
 
 MVP の検索は case-sensitive です。
@@ -188,6 +196,8 @@ MVP の検索は case-sensitive です。
 MVP Node CLI の regex は Node.js `RegExp` を使い、content 検索では行ごとに match します。複数行 regex は MVP 外です。
 
 JavaScript 固有の regex flags は MVP では受け取りません。将来の Java CLI では regex engine が異なる可能性があるため、cross-runtime の完全同一挙動は保証しません。
+
+regex pattern text は 1000 文字以下に制限します。`(.+)+` や `(a*)+` のような nested quantified group は ReDoS リスクを避けるため validation error とします。
 
 ## 詳細仕様
 

--- a/TODO.md
+++ b/TODO.md
@@ -175,6 +175,8 @@
     - `invalid_search_target`
     - `invalid_output_mode`
     - `invalid_regex`
+    - `regex_too_large`
+    - `unsafe_regex`
     - `root_not_found`
     - `root_not_accessible`
     - `root_too_broad`
@@ -182,6 +184,9 @@
     - `max_matches_too_large`
     - `max_matches_per_file_too_large`
     - `max_depth_too_large`
+    - `max_line_chars_too_large`
+    - `max_files_visited_too_large`
+    - `max_directories_visited_too_large`
     - `max_line_length_too_large`
     - `max_snippets_per_file_too_large`
     - `max_file_bytes_too_large`
@@ -194,9 +199,48 @@
     - `max_file_bytes_exceeded`
     - `binary_file_skipped`
     - `decode_error`
+    - `max_line_chars_exceeded`
+    - `path_escape_skipped`
     - `max_matches`
     - `max_matches_per_file`
     - `max_snippets_per_file`
+    - `max_files_visited`
+    - `max_directories_visited`
+
+## security follow-up
+
+- [x] Regex ReDoS 対策を検討・実装する
+  - 現状: `query.type: "regex"` は Node.js `RegExp` を直接使う。
+  - リスク: catastrophic backtracking により CPU を長時間消費する可能性がある。
+  - 実装: regex pattern length 上限と nested quantified group の最小 heuristic reject を追加。
+  - 残課題: 完全な ReDoS 対策ではないため、RE2 系 engine または worker thread timeout は必要になった段階で再検討する。
+
+- [x] traversal / file count DoS 対策を追加する
+  - 現状: `maxDepth`、`maxFileBytes`、match limit はあるが、訪問ファイル数・訪問ディレクトリ数の上限はない。
+  - 実装: `search.maxFilesVisited`、`search.maxDirectoriesVisited` を追加し、limit 到達時に `max_files_visited` / `max_directories_visited` diagnostic を返す。
+
+- [x] TOCTOU リスクを整理する
+  - 現状: `fs.realpath()` で root 境界を確認してから `fs.readFile()` する。
+  - リスク: 確認後から read 前までに file が差し替えられる可能性がある。
+  - 実装: local-first CLI としての残リスクを security docs に明記。file descriptor ベースの実装は必要になった段階で再検討する。
+
+- [x] filename / diagnostics による情報漏えいを整理する
+  - filename search は content を読まなくても file / path 名を返す。
+  - diagnostics は unreadable path、decode error、path escape など repository 構造を返す。
+  - 実装: security docs に agent 向け利便性と権限境界としての扱いを明記。
+
+- [x] long line / binary-like text の resource risk を検討する
+  - `maxLineLength` は output snippet 制限であり、入力 line 処理そのものの上限ではない。
+  - NUL を含まない binary-like file は decode / line split 対象になり得る。
+  - 実装: `search.maxLineChars` を追加し、超過行は `max_line_chars_exceeded` diagnostic として skip。
+  - 残課題: NUL を含まない binary-like file の byte heuristic や追加 default exclude は必要になった段階で再検討する。
+
+- [x] downstream injection / prompt injection を docs に追記する
+  - `miku-grep` は JSON として escape して返すが、caller が shell / HTML / SQL / Markdown / prompt に再埋め込みする場合は別途 escape が必要。
+  - 実装: 検索結果本文は信頼できない入力であり、agent が命令として扱わないことを security docs に明記。
+
+- [x] security 実装と CLI spec の同期を取る
+  - 実装: `request.root` realpath 境界チェック、`path_escape_skipped`、traversal limit、security diagnostic の扱いを `docs/miku-grep-cli-spec.md` に反映。
 
 ## later refactoring candidates
 

--- a/docs/miku-grep-cli-spec.md
+++ b/docs/miku-grep-cli-spec.md
@@ -162,6 +162,8 @@ Result `file` values are relative paths from `request.root`. Absolute paths must
 
 Result paths must use `/` as the path separator on every platform, including Windows.
 
+The implementation should resolve `request.root` with realpath semantics and treat that realpath as the search boundary. During traversal, if a directory or file resolves outside the root realpath, it must be skipped and reported as a diagnostic instead of being read.
+
 Examples:
 
 ```text
@@ -215,6 +217,10 @@ Content regex search is applied line by line. Multi-line regex matching is outsi
 
 MVP does not accept JavaScript-specific regex flags.
 
+Regex pattern text must not exceed 1000 characters.
+
+Implementations should reject common ReDoS-prone nested quantified groups, such as `(.+)+` or `(a*)+`, as `unsafe_regex`.
+
 A future Java CLI may use Java's regex engine. Cross-runtime regex behavior is not guaranteed to be identical for all edge cases. Prefer portable basic regex patterns when the same request should work across Node and Java runtimes.
 
 ### search
@@ -257,9 +263,36 @@ Search defaults:
 {
   "recursive": true,
   "maxDepth": 20,
-  "maxFileBytes": 10485760
+  "maxFileBytes": 10485760,
+  "maxLineChars": 1000000,
+  "maxFilesVisited": 100000,
+  "maxDirectoriesVisited": 10000
 }
 ```
+
+### traversal resource limits
+
+`search.maxFilesVisited` limits the number of files discovered by traversal before include / exclude and binary skip.
+
+Default: `100000`
+
+Maximum: `1000000`
+
+`search.maxDirectoriesVisited` limits the number of directories entered by traversal.
+
+Default: `10000`
+
+Maximum: `100000`
+
+### maxLineChars
+
+`search.maxLineChars` limits the number of decoded characters searched from a single line.
+
+Default: `1000000`
+
+Maximum: `10000000`
+
+Lines longer than `search.maxLineChars` are skipped for content search and reported in `diagnostics[]`.
 
 ### include / exclude
 
@@ -508,6 +541,9 @@ Successful result example:
       "recursive": true,
       "maxDepth": 8,
       "maxFileBytes": 10485760,
+      "maxLineChars": 1000000,
+      "maxFilesVisited": 100000,
+      "maxDirectoriesVisited": 10000,
       "includeFileNamePatterns": ["*.java", "*.md"],
       "excludeFileNamePatterns": ["*.class", "*.jar", "*.zip", "*.png", "*.jpg", "*.jpeg", "*.gif", "*.pdf", ".classpath", ".project", "*.generated.md"],
       "excludeDirNamePatterns": [".git", ".svn", "node_modules", "target", "build", "dist", ".gradle", ".idea", ".vscode", ".settings", "vendor", "tmp"]
@@ -576,7 +612,10 @@ Expected failure example:
       "target": "content",
       "recursive": true,
       "maxDepth": 8,
-      "maxFileBytes": 10485760
+      "maxFileBytes": 10485760,
+      "maxLineChars": 1000000,
+      "maxFilesVisited": 100000,
+      "maxDirectoriesVisited": 10000
     },
     "output": {
       "mode": "detail",
@@ -815,11 +854,17 @@ file_not_readable
 max_file_bytes_exceeded
   file exceeded search.maxFileBytes and was skipped
 
+max_line_chars_exceeded
+  line exceeded search.maxLineChars and was skipped
+
 binary_file_skipped
   file was treated as binary and skipped during content search
 
 decode_error
   file could not be decoded with the applied encoding rule and was skipped
+
+path_escape_skipped
+  path resolved outside request.root realpath and was skipped
 
 max_matches
   search stopped because output.maxMatches was reached
@@ -829,6 +874,12 @@ max_matches_per_file
 
 max_snippets_per_file
   file-summary snippets were omitted because output.maxSnippetsPerFile was reached
+
+max_files_visited
+  search stopped because search.maxFilesVisited was reached
+
+max_directories_visited
+  search stopped because search.maxDirectoriesVisited was reached
 ```
 
 ## Summary
@@ -874,7 +925,7 @@ truncated
 
 truncatedReason
   Main truncation reason when truncated is true.
-  Candidate values: max_matches / max_matches_per_file / max_line_length / max_snippets_per_file
+  Candidate values: max_matches / max_matches_per_file / max_line_length / max_snippets_per_file / max_line_chars_exceeded / max_files_visited / max_directories_visited
 ```
 
 ## Dangerous Requests
@@ -891,6 +942,9 @@ Examples:
 - `maxMatches` is too large
 - `maxMatchesPerFile` is too large
 - `maxDepth` is too large
+- `maxLineChars` is too large
+- `maxFilesVisited` is too large
+- `maxDirectoriesVisited` is too large
 - `maxLineLength` is too large
 - `maxSnippetsPerFile` is too large
 - `maxFileBytes` is too large
@@ -911,6 +965,8 @@ invalid_query_type
 invalid_search_target
 invalid_output_mode
 invalid_regex
+regex_too_large
+unsafe_regex
 root_not_found
 root_not_accessible
 root_too_broad
@@ -918,6 +974,9 @@ empty_query
 max_matches_too_large
 max_matches_per_file_too_large
 max_depth_too_large
+max_line_chars_too_large
+max_files_visited_too_large
+max_directories_visited_too_large
 max_line_length_too_large
 max_snippets_per_file_too_large
 max_file_bytes_too_large

--- a/docs/miku-grep-security.md
+++ b/docs/miku-grep-security.md
@@ -1,0 +1,182 @@
+# miku-grep Security Notes v20260502
+
+## 目的
+
+この文書は、`miku-grep` のセキュリティに関する調査結果、現時点の対策、残っているリスク、今後の検討事項を記録する。
+
+`miku-grep` は local-first な検索 CLI であり、主な入力は stdin の request JSON、主な出力は stdout の result JSON である。生成AI agent や automation から呼び出される前提があるため、通常の CLI よりも「入力が機械生成される」「検索 root が外部から指定される」「結果 JSON を後続処理が機械的に読む」点を重視する。
+
+## セキュリティ方針
+
+- stdout は JSON result 専用にする。
+- 期待可能な失敗は result JSON の `ok: false` と diagnostics で返す。
+- 予期しない runtime-level message は stderr に出す。
+- request JSON の未知 field は validation error にする。
+- 推測で危険な読み取りを続行しない。
+- root、realpath、symlink、encoding、file size、match limit を明示的に扱う。
+
+## JSON injection
+
+### 調査結果
+
+現実装では、result JSON は object を構築したうえで `JSON.stringify(result, null, 2)` により出力している。
+
+検索対象ファイルの内容、ファイル名、diagnostic message、matched text は JSON 文字列値として escape されるため、検索対象に `"`、改行、`}`、`,` などが含まれていても JSON 構造を壊す形の injection は起きにくい。
+
+### 現在の対策
+
+- stdout result は `JSON.stringify` で生成する。
+- 手作業の string concatenation で JSON を組み立てない。
+- stdout に progress log や human-readable log を混ぜない。
+- request の未知 field は拒否し、typo や意図しない入力を黙って無視しない。
+
+### 残リスク
+
+後続の caller が result JSON 内の文字列を別の文脈、たとえば shell command、HTML、SQL、Markdown、別の JSON template に未 escape で埋め込む場合、その後続文脈で injection が発生し得る。
+
+`miku-grep` 側では JSON として正しく escape して返すことが責務であり、後続文脈への再埋め込み時は caller 側で文脈別 escape が必要である。
+
+## Regex injection / ReDoS
+
+### 調査結果
+
+`query.type: "regex"` では、ユーザー指定の `query.text` を Node.js `RegExp` として扱う。
+
+これは shell や SQL のような injection ではないが、正規表現そのものが実行されるため、意図しない広範囲 match や catastrophic backtracking による ReDoS のリスクがある。
+
+### 現在の対策
+
+- invalid regex は validation error `invalid_regex` として拒否する。
+- regex pattern length は 1000 文字以下に制限し、超過時は `regex_too_large` として拒否する。
+- `(.+)+` や `(a*)+` のような nested quantified group は `unsafe_regex` として拒否する。
+- regex flags は public schema として受け取らない。
+- content regex は行ごとに適用し、複数行 regex は MVP 外としている。
+- `search.maxFileBytes`、`output.maxMatches`、`output.maxMatchesPerFile` に上限を設けている。
+
+### 残リスク
+
+Node.js の標準 `RegExp` は、pattern によっては 1 行の検索でも非常に時間がかかる可能性がある。現時点の nested quantified group reject は代表的な危険 pattern を拒否する最小 heuristic であり、完全な safe-regex 判定ではない。regex 実行単位の timeout は入れていない。
+
+今後の対策候補:
+
+- automation 向けに regex を無効化する実行モードを追加する。
+- より厳密な safe-regex 判定を導入する。
+- RE2 系 engine の利用を検討する。
+- worker thread で regex 検索を実行し、timeout で中断する。
+
+## Path traversal / root escape
+
+### 調査結果
+
+`request.root` は検索範囲を決める重要な入力である。相対 path、絶対 path、symlink を経由すると、探索中に `request.root` 配下ではない場所へ移動してしまう可能性がある。
+
+Java でいう `Path.toRealPath()` や `File.getCanonicalPath()` に相当する処理として、Node.js では `fs.realpath()` を使う。単純な文字列 `startsWith(base)` では `/tmp/base` と `/tmp/base2` のような prefix 衝突を誤判定し得るため、`path.relative(base, candidate)` を使って配下判定する。
+
+### 現在の対策
+
+- `request.root` は `path.resolve(process.cwd(), root)` で絶対 path 化する。
+- root は `fs.realpath()` で symlink 解決後の実体 path にし、この realpath を検索境界として扱う。
+- root が filesystem root または user home directory の場合は `root_too_broad` として拒否する。
+- 探索中の directory / file も `fs.realpath()` で解決し、検索 root 外に出る path は `path_escape_skipped` として skip する。
+- symlink entry は通常探索対象にせず、`symlink_skipped` diagnostic として返す。
+
+配下判定の基本形:
+
+```ts
+const base = await fs.realpath(baseDir);
+const candidate = await fs.realpath(targetPath);
+const relative = path.relative(base, candidate);
+const inside = relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+```
+
+## Symlink
+
+### 調査結果
+
+symlink は root escape の代表的な経路である。root 配下に見える path でも、実体が root 外にある場合がある。
+
+### 現在の対策
+
+- directory traversal 中に `Dirent.isSymbolicLink()` が true の entry は skip する。
+- root 自体が symlink の場合も `fs.realpath()` で実体 path を確認する。
+- 探索中の file read 前にも realpath 境界チェックを行う。
+
+## TOCTOU
+
+### 調査結果
+
+現在の実装は、directory / file の `fs.realpath()` を確認した後に `fs.readdir()` や `fs.readFile()` を行う。このため、確認後から read 前までの短い間に file system entry が差し替えられる race condition は理論上残る。
+
+### 現在の整理
+
+`miku-grep` は local-first CLI であり、敵対的な別プロセスが同じ workspace を同時に書き換える状況を強い権限境界として防ぐ設計ではない。通常の agent / automation が自分の workspace を読む用途では、realpath 境界チェックと symlink skip を主対策とする。
+
+より強い TOCTOU 対策が必要になった場合は、file descriptor ベースの open / fstat / read、platform ごとの `O_NOFOLLOW` 相当、または sandbox 側の読み取り権限制限を検討する。
+
+## File size / binary / encoding
+
+### 調査結果
+
+巨大ファイル、binary file、decode 不能な file は、処理時間、メモリ、文字化け、後続処理の誤動作につながる。
+
+### 現在の対策
+
+- `search.maxFileBytes` default は 10 MiB。
+- `search.maxFileBytes` の最大許容値は 100 MiB。
+- `search.maxLineChars` default は 1000000、最大許容値は 10000000。
+- decode 後の 1 行が `search.maxLineChars` を超える場合、その行は `max_line_chars_exceeded` として skip する。
+- NUL byte を含む file は binary とみなし `binary_file_skipped` として skip する。
+- 対応 encoding は `utf-8` と `shift_jis` に限定する。
+- UTF-8 decode は fatal mode で行い、decode できない file は `decode_error` として skip する。
+- Shift_JIS decode は明示的な encoding rule または default 指定に基づいて行う。
+
+## Output size / resource limits
+
+### 現在の対策
+
+- `output.maxMatches` の最大許容値は 10000。
+- `output.maxMatchesPerFile` の最大許容値は 1000。
+- `output.maxLineLength` の最大許容値は 4000。
+- `output.maxSnippetsPerFile` の最大許容値は 100。
+- `search.maxDepth` の最大許容値は 50。
+- `search.maxFilesVisited` の default は 100000、最大許容値は 1000000。
+- `search.maxDirectoriesVisited` の default は 10000、最大許容値は 100000。
+- limit 到達時は diagnostics に `max_matches`、`max_matches_per_file`、`max_snippets_per_file` を返す。
+- traversal limit 到達時は diagnostics に `max_files_visited`、`max_directories_visited` を返す。
+
+## Filename / diagnostics information disclosure
+
+### 調査結果
+
+filename search は file content を読まなくても root-relative path を返す。diagnostics も unreadable path、decode error、path escape、symlink skip など repository 構造に関する情報を返す。
+
+これは agent が次に読むべき file を判断するためには有用だが、`miku-grep` を権限境界として使う場合には情報漏えいになる可能性がある。
+
+### 現在の整理
+
+`miku-grep` は local-first CLI であり、request.root 配下を読める caller が、その範囲の file / path 情報を得ることを前提にしている。権限のない user に対して result JSON をそのまま公開する用途は想定しない。
+
+## Downstream injection / prompt injection
+
+### 調査結果
+
+`miku-grep` 自体は JSON として escape した result を返す。しかし caller が result 内の `text`、`matchedText`、`file`、diagnostics を shell、HTML、SQL、Markdown、prompt など別の文脈に再埋め込みする場合、その文脈での injection が発生し得る。
+
+検索対象 file の本文は信頼できない入力である。agent が検索結果の本文をそのまま命令として扱うと prompt injection になる。
+
+### 運用上の推奨
+
+- caller は result JSON 内の文字列を再利用する文脈ごとに escape する。
+- agent は検索結果本文を「観測データ」として扱い、system / developer instruction と同等の命令として扱わない。
+- prompt に検索結果を入れる場合は、引用範囲や信頼境界を明示する。
+
+## 現時点の主な残課題
+
+- regex ReDoS 対策は追加検討が必要。
+- `request.root` realpath 境界チェックを正式 CLI spec にも反映する。
+- path escape の追加テストを symlink 以外の race condition 観点でも検討する。
+- agent / MCP / skill から呼び出す場合の推奨 result handling contract を別途整理する。
+
+## 変更履歴
+
+- 2026-05-02: 初版作成。JSON injection、regex / ReDoS、root escape、symlink、file size、encoding、output limit の調査結果と対策を記録。

--- a/src/help.ts
+++ b/src/help.ts
@@ -56,6 +56,15 @@ REQUEST FIELDS
   search.maxFileBytes
     Content-read size limit. Default: 10485760. Maximum: 104857600.
 
+  search.maxLineChars
+    Per-line scan limit after decode. Default: 1000000. Maximum: 10000000.
+
+  search.maxFilesVisited
+    Traversal file visit limit. Default: 100000. Maximum: 1000000.
+
+  search.maxDirectoriesVisited
+    Traversal directory visit limit. Default: 10000. Maximum: 100000.
+
   search.includeFileNamePatterns
     Optional glob array. Empty or missing means no include restriction.
     MVP glob supports "*" and "?" within one basename.
@@ -207,14 +216,18 @@ COMMON DIAGNOSTIC CODES
   Validation / expected failures:
     invalid_request, unknown_field, invalid_version, invalid_query_type,
     invalid_search_target, invalid_output_mode, invalid_regex,
+    regex_too_large, unsafe_regex,
     root_not_found, root_not_accessible, root_too_broad, empty_query,
     max_matches_too_large, max_matches_per_file_too_large, max_depth_too_large,
     max_line_length_too_large, max_snippets_per_file_too_large,
-    max_file_bytes_too_large, invalid_encoding, invalid_encoding_rule
+    max_file_bytes_too_large, max_line_chars_too_large, max_files_visited_too_large,
+    max_directories_visited_too_large, invalid_encoding, invalid_encoding_rule
   Runtime diagnostics:
     directory_not_readable, symlink_skipped, file_not_readable,
     max_file_bytes_exceeded, binary_file_skipped, decode_error,
-    max_matches, max_matches_per_file, max_snippets_per_file
+    path_escape_skipped, max_matches, max_matches_per_file,
+    max_snippets_per_file, max_line_chars_exceeded,
+    max_files_visited, max_directories_visited
 
 EXAMPLES
   Content search:

--- a/src/internal-types.ts
+++ b/src/internal-types.ts
@@ -17,5 +17,6 @@ export type SearchState = {
   diagnostics: Diagnostic[];
   truncationDiagnosticKeys: Set<string>;
   summary: Summary;
+  directoriesVisited: number;
   globalLimitReached: boolean;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -91,11 +91,11 @@ export async function runRequest(request: unknown): Promise<MikuGrepResult> {
     return finish(false, rootCheck.diagnostic.code, rootCheck.diagnostic.message, effectiveRequest, [], baseSummary, diagnostics);
   }
 
-  const searchResult = await runSearch(effectiveRequest, rootPath, diagnostics);
+  const searchResult = await runSearch(effectiveRequest, rootCheck.realPath, diagnostics);
   return finish(true, null, null, effectiveRequest, searchResult.matches, searchResult.summary, diagnostics);
 }
 
-async function checkRoot(rootPath: string, requestRoot: string): Promise<{ ok: true } | { ok: false; diagnostic: Diagnostic }> {
+async function checkRoot(rootPath: string, requestRoot: string): Promise<{ ok: true; realPath: string } | { ok: false; diagnostic: Diagnostic }> {
   if (path.parse(rootPath).root === rootPath || rootPath === homeDirectory()) {
     return rootError("root_too_broad", "root is too broad", requestRoot);
   }
@@ -103,7 +103,8 @@ async function checkRoot(rootPath: string, requestRoot: string): Promise<{ ok: t
     const stat = await fs.stat(rootPath);
     if (!stat.isDirectory()) return rootError("root_not_accessible", "root is not a directory", requestRoot);
     await fs.access(rootPath, fsConstants.R_OK);
-    return { ok: true };
+    const realPath = await fs.realpath(rootPath);
+    return { ok: true, realPath };
   } catch (error) {
     const code = isNodeError(error) && error.code === "ENOENT" ? "root_not_found" : "root_not_accessible";
     return rootError(code, code === "root_not_found" ? "root does not exist" : "root is not accessible", requestRoot);

--- a/src/path-security.ts
+++ b/src/path-security.ts
@@ -1,0 +1,6 @@
+import path from "node:path";
+
+export function isPathInsideOrSame(candidate: string, base: string): boolean {
+  const relative = path.relative(base, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}

--- a/src/public-types.ts
+++ b/src/public-types.ts
@@ -15,6 +15,9 @@ export type MikuGrepRequest = {
     recursive?: boolean;
     maxDepth?: number;
     maxFileBytes?: number;
+    maxLineChars?: number;
+    maxFilesVisited?: number;
+    maxDirectoriesVisited?: number;
     includeFileNamePatterns?: string[];
     excludeFileNamePatterns?: string[];
     excludeDirNamePatterns?: string[];
@@ -55,6 +58,9 @@ export type EffectiveRequest = {
     recursive: boolean;
     maxDepth: number;
     maxFileBytes: number;
+    maxLineChars: number;
+    maxFilesVisited: number;
+    maxDirectoriesVisited: number;
     includeFileNamePatterns: string[];
     excludeFileNamePatterns: string[];
     excludeDirNamePatterns: string[];

--- a/src/regex-safety.ts
+++ b/src/regex-safety.ts
@@ -1,0 +1,43 @@
+export function hasNestedQuantifiedGroup(pattern: string): boolean {
+  const stack: Array<{ hasQuantifier: boolean }> = [];
+  let escaped = false;
+  let inCharClass = false;
+
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index] ?? "";
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === "\\") {
+      escaped = true;
+      continue;
+    }
+    if (inCharClass) {
+      if (char === "]") inCharClass = false;
+      continue;
+    }
+    if (char === "[") {
+      inCharClass = true;
+      continue;
+    }
+    if (char === "(") {
+      stack.push({ hasQuantifier: false });
+      continue;
+    }
+    if (char === ")") {
+      const group = stack.pop();
+      if (!group) continue;
+      const next = pattern[index + 1] ?? "";
+      const groupIsQuantified = next === "*" || next === "+" || next === "?" || next === "{";
+      if (group.hasQuantifier && groupIsQuantified) return true;
+      if (group.hasQuantifier && stack.length > 0) stack[stack.length - 1]!.hasQuantifier = true;
+      continue;
+    }
+    if ((char === "*" || char === "+" || char === "?" || char === "{") && stack.length > 0) {
+      stack[stack.length - 1]!.hasQuantifier = true;
+    }
+  }
+
+  return false;
+}

--- a/src/request-contract.ts
+++ b/src/request-contract.ts
@@ -1,0 +1,88 @@
+export const VERSION = 1;
+
+export const DEFAULT_EXCLUDE_DIRS = [
+  ".git",
+  ".svn",
+  "node_modules",
+  "target",
+  "build",
+  "dist",
+  ".gradle",
+  ".idea",
+  ".vscode",
+  ".settings",
+  "vendor",
+];
+
+export const DEFAULT_EXCLUDE_FILES = [
+  "*.class",
+  "*.jar",
+  "*.zip",
+  "*.png",
+  "*.jpg",
+  "*.jpeg",
+  "*.gif",
+  "*.pdf",
+  ".classpath",
+  ".project",
+];
+
+export const LIMITS = {
+  regexPatternLength: 1000,
+  maxDepth: 50,
+  maxFileBytes: 104857600,
+  maxLineChars: 10000000,
+  maxFilesVisited: 1000000,
+  maxDirectoriesVisited: 100000,
+  maxMatches: 10000,
+  maxMatchesPerFile: 1000,
+  maxLineLength: 4000,
+  maxSnippetsPerFile: 100,
+};
+
+export const DEFAULTS = {
+  search: {
+    target: "content",
+    recursive: true,
+    maxDepth: 20,
+    maxFileBytes: 10485760,
+    maxLineChars: 1000000,
+    maxFilesVisited: 100000,
+    maxDirectoriesVisited: 10000,
+    includeFileNamePatterns: [] as string[],
+    excludeFileNamePatterns: [] as string[],
+    excludeDirNamePatterns: [] as string[],
+  },
+  output: {
+    mode: "file-summary",
+    maxMatches: 200,
+    maxMatchesPerFile: 20,
+    maxLineLength: 240,
+    maxSnippetsPerFile: 3,
+  },
+  encoding: {
+    default: "utf-8",
+    rules: [],
+    onDecodeError: "skip",
+  },
+} as const;
+
+export const REQUEST_SHAPE = {
+  version: true,
+  root: true,
+  query: { type: true, text: true },
+  search: {
+    target: true,
+    recursive: true,
+    maxDepth: true,
+    maxFileBytes: true,
+    maxLineChars: true,
+    maxFilesVisited: true,
+    maxDirectoriesVisited: true,
+    includeFileNamePatterns: true,
+    excludeFileNamePatterns: true,
+    excludeDirNamePatterns: true,
+  },
+  output: { mode: true, maxMatches: true, maxMatchesPerFile: true, maxLineLength: true, maxSnippetsPerFile: true },
+  encoding: { default: true, rules: true, onDecodeError: true },
+} satisfies Record<string, true | Record<string, unknown>>;

--- a/src/search.ts
+++ b/src/search.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import iconv from "iconv-lite";
 import { globMatch, matchesAny, pathGlobMatch } from "./glob.js";
+import { isPathInsideOrSame } from "./path-security.js";
 import { createSummary } from "./result.js";
 import type { SearchResult, SearchState } from "./internal-types.js";
 import type {
@@ -23,6 +24,7 @@ export async function runSearch(request: EffectiveRequest, rootPath: string, dia
     diagnostics,
     truncationDiagnosticKeys: new Set(),
     summary: createSummary(),
+    directoriesVisited: 0,
     globalLimitReached: false,
   };
 
@@ -35,9 +37,19 @@ export async function runSearch(request: EffectiveRequest, rootPath: string, dia
 
 async function traverse(state: SearchState, absoluteDir: string, relativeDir: string, depth: number): Promise<void> {
   if (state.globalLimitReached) return;
+  if (state.directoriesVisited >= state.request.search.maxDirectoriesVisited) {
+    markTruncated(state, "max_directories_visited", "search stopped because maxDirectoriesVisited was reached", { maxDirectoriesVisited: state.request.search.maxDirectoriesVisited });
+    state.globalLimitReached = true;
+    return;
+  }
+  state.directoriesVisited += 1;
+
+  const safeDir = await resolveInsideRoot(state, absoluteDir, relativeDir || ".");
+  if (!safeDir) return;
+
   let entries;
   try {
-    entries = await fs.readdir(absoluteDir, { withFileTypes: true });
+    entries = await fs.readdir(safeDir, { withFileTypes: true });
   } catch {
     state.diagnostics.push({ severity: "warning", code: "directory_not_readable", message: "directory could not be read and was skipped", path: relativeDir || ".", skipped: true });
     return;
@@ -46,7 +58,7 @@ async function traverse(state: SearchState, absoluteDir: string, relativeDir: st
   for (const entry of entries) {
     if (state.globalLimitReached) return;
     const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
-    const absolutePath = path.join(absoluteDir, entry.name);
+    const absolutePath = path.join(safeDir, entry.name);
     if (entry.isSymbolicLink()) {
       state.diagnostics.push({ severity: "info", code: "symlink_skipped", message: "symlink was skipped", path: relativePath, skipped: true });
       continue;
@@ -58,6 +70,11 @@ async function traverse(state: SearchState, absoluteDir: string, relativeDir: st
       continue;
     }
     if (!entry.isFile()) continue;
+    if (state.summary.filesVisited >= state.request.search.maxFilesVisited) {
+      markTruncated(state, "max_files_visited", "search stopped because maxFilesVisited was reached", { maxFilesVisited: state.request.search.maxFilesVisited });
+      state.globalLimitReached = true;
+      return;
+    }
     state.summary.filesVisited += 1;
     if (!candidateFile(state, entry.name)) continue;
     await searchFile(state, absolutePath, relativePath, entry.name);
@@ -82,9 +99,17 @@ async function searchFile(state: SearchState, absolutePath: string, relativePath
   }
   if (target !== "content" && target !== "both") return;
 
+  const safePath = await resolveInsideRoot(state, absolutePath, relativePath);
+  if (!safePath) return;
+
   let stat;
   try {
-    stat = await fs.stat(absolutePath);
+    const lstat = await fs.lstat(safePath);
+    if (lstat.isSymbolicLink()) {
+      state.diagnostics.push({ severity: "info", code: "symlink_skipped", message: "symlink was skipped", path: relativePath, skipped: true });
+      return;
+    }
+    stat = await fs.stat(safePath);
   } catch {
     state.diagnostics.push({ severity: "warning", code: "file_not_readable", message: "file could not be read and was skipped", file: relativePath, skipped: true });
     return;
@@ -95,7 +120,7 @@ async function searchFile(state: SearchState, absolutePath: string, relativePath
   }
   let bytes;
   try {
-    bytes = await fs.readFile(absolutePath);
+    bytes = await fs.readFile(safePath);
   } catch {
     state.diagnostics.push({ severity: "warning", code: "file_not_readable", message: "file could not be read and was skipped", file: relativePath, skipped: true });
     return;
@@ -119,12 +144,16 @@ async function searchFile(state: SearchState, absolutePath: string, relativePath
   const lines = splitLines(text);
   let fileHitCount = state.summariesByFile.get(relativePath)?.matchCount ?? 0;
   for (let index = 0; index < lines.length; index += 1) {
-    for (const match of findMatches(lines[index] ?? "", state.request.query)) {
+    const line = lines[index] ?? "";
+    if (line.length > state.request.search.maxLineChars) {
+      markLineSkipped(state, relativePath, index + 1, line.length);
+      continue;
+    }
+    for (const match of findMatches(line, state.request.query)) {
       if (fileHitCount >= state.request.output.maxMatchesPerFile) {
         markTruncated(state, "max_matches_per_file", "file search stopped because maxMatchesPerFile was reached", { file: relativePath, maxMatchesPerFile: state.request.output.maxMatchesPerFile });
         return;
       }
-      const line = lines[index] ?? "";
       const snippet = makeSnippet(line, match.index, match.text.length, state.request.output.maxLineLength);
       addHit(state, relativePath, {
         type: "content",
@@ -142,6 +171,37 @@ async function searchFile(state: SearchState, absolutePath: string, relativePath
       if (state.globalLimitReached) return;
     }
   }
+}
+
+function markLineSkipped(state: SearchState, file: string, line: number, lineChars: number): void {
+  if (!state.summary.truncated) {
+    state.summary.truncated = true;
+    state.summary.truncatedReason = "max_line_chars_exceeded";
+  }
+  state.diagnostics.push({
+    severity: "warning",
+    code: "max_line_chars_exceeded",
+    message: "line exceeded maxLineChars and was skipped",
+    file,
+    line,
+    skipped: true,
+    details: { lineChars, maxLineChars: state.request.search.maxLineChars },
+  });
+}
+
+async function resolveInsideRoot(state: SearchState, absolutePath: string, relativePath: string): Promise<string | null> {
+  let realPath;
+  try {
+    realPath = await fs.realpath(absolutePath);
+  } catch {
+    state.diagnostics.push({ severity: "warning", code: "file_not_readable", message: "path could not be resolved and was skipped", path: relativePath, skipped: true });
+    return null;
+  }
+  if (!isPathInsideOrSame(realPath, state.rootPath)) {
+    state.diagnostics.push({ severity: "warning", code: "path_escape_skipped", message: "path resolved outside root and was skipped", path: relativePath, skipped: true });
+    return null;
+  }
+  return realPath;
 }
 
 function addHit(state: SearchState, file: string, hit: DetailMatch): void {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,83 +1,13 @@
 import type { ValidationResult } from "./internal-types.js";
+import { hasNestedQuantifiedGroup } from "./regex-safety.js";
+import { DEFAULT_EXCLUDE_DIRS, DEFAULT_EXCLUDE_FILES, DEFAULTS, LIMITS, REQUEST_SHAPE, VERSION } from "./request-contract.js";
 import type { EffectiveRequest, EncodingRuleInput, QueryType, SupportedEncoding } from "./public-types.js";
 
-export const VERSION = 1;
-
-const DEFAULT_EXCLUDE_DIRS = [
-  ".git",
-  ".svn",
-  "node_modules",
-  "target",
-  "build",
-  "dist",
-  ".gradle",
-  ".idea",
-  ".vscode",
-  ".settings",
-  "vendor",
-];
-const DEFAULT_EXCLUDE_FILES = [
-  "*.class",
-  "*.jar",
-  "*.zip",
-  "*.png",
-  "*.jpg",
-  "*.jpeg",
-  "*.gif",
-  "*.pdf",
-  ".classpath",
-  ".project",
-];
-const LIMITS = {
-  maxDepth: 50,
-  maxFileBytes: 104857600,
-  maxMatches: 10000,
-  maxMatchesPerFile: 1000,
-  maxLineLength: 4000,
-  maxSnippetsPerFile: 100,
-};
-const DEFAULTS = {
-  search: {
-    target: "content",
-    recursive: true,
-    maxDepth: 20,
-    maxFileBytes: 10485760,
-    includeFileNamePatterns: [] as string[],
-    excludeFileNamePatterns: [] as string[],
-    excludeDirNamePatterns: [] as string[],
-  },
-  output: {
-    mode: "file-summary",
-    maxMatches: 200,
-    maxMatchesPerFile: 20,
-    maxLineLength: 240,
-    maxSnippetsPerFile: 3,
-  },
-  encoding: {
-    default: "utf-8",
-    rules: [],
-    onDecodeError: "skip",
-  },
-} as const;
+export { VERSION } from "./request-contract.js";
 
 export function validateAndNormalize(request: unknown): ValidationResult {
   if (!isPlainObject(request)) return invalid("invalid_request", "request must be an object");
-  const unknown = findUnknownField(request, {
-    version: true,
-    root: true,
-    query: { type: true, text: true },
-    search: {
-      target: true,
-      recursive: true,
-      maxDepth: true,
-      maxFileBytes: true,
-      includeFileNamePatterns: true,
-      excludeFileNamePatterns: true,
-      excludeDirNamePatterns: true,
-    },
-    output: { mode: true, maxMatches: true, maxMatchesPerFile: true, maxLineLength: true, maxSnippetsPerFile: true },
-    encoding: { default: true, rules: true, onDecodeError: true },
-  });
+  const unknown = findUnknownField(request, REQUEST_SHAPE);
   if (unknown) return invalid("unknown_field", `unknown field: ${unknown}`);
   if (request.version !== VERSION) return invalid("invalid_version", "version must be 1");
   if (typeof request.root !== "string" || request.root.length === 0) return invalid("invalid_request", "root must be a non-empty string");
@@ -86,11 +16,13 @@ export function validateAndNormalize(request: unknown): ValidationResult {
   if (typeof request.query.text !== "string") return invalid("invalid_request", "query.text must be a string");
   if (request.query.text.length === 0) return invalid("empty_query", "query.text must not be empty");
   if (request.query.type === "regex") {
+    if (request.query.text.length > LIMITS.regexPatternLength) return invalid("regex_too_large", "query.text regex pattern is too large");
     try {
       new RegExp(request.query.text);
     } catch {
       return invalid("invalid_regex", "query.text is not a valid regular expression");
     }
+    if (hasNestedQuantifiedGroup(request.query.text)) return invalid("unsafe_regex", "query.text regex pattern has nested quantified groups");
   }
 
   const searchInput = request.search ?? {};
@@ -105,16 +37,24 @@ export function validateAndNormalize(request: unknown): ValidationResult {
     recursive: searchInput.recursive ?? DEFAULTS.search.recursive,
     maxDepth: searchInput.maxDepth ?? DEFAULTS.search.maxDepth,
     maxFileBytes: searchInput.maxFileBytes ?? DEFAULTS.search.maxFileBytes,
+    maxLineChars: searchInput.maxLineChars ?? DEFAULTS.search.maxLineChars,
+    maxFilesVisited: searchInput.maxFilesVisited ?? DEFAULTS.search.maxFilesVisited,
+    maxDirectoriesVisited: searchInput.maxDirectoriesVisited ?? DEFAULTS.search.maxDirectoriesVisited,
     includeFileNamePatterns: searchInput.includeFileNamePatterns ?? [],
     excludeFileNamePatterns: searchInput.excludeFileNamePatterns ?? [],
     excludeDirNamePatterns: searchInput.excludeDirNamePatterns ?? [],
   };
   if (!["content", "filename", "both"].includes(search.target)) return invalid("invalid_search_target", "search.target must be content, filename, or both");
   if (typeof search.recursive !== "boolean") return invalid("invalid_request", "search.recursive must be boolean");
-  if (!isSafeInteger(search.maxDepth) || search.maxDepth < 0) return invalid("invalid_request", "search.maxDepth must be a non-negative integer");
-  if (search.maxDepth > LIMITS.maxDepth) return invalid("max_depth_too_large", "search.maxDepth is too large");
-  if (!isSafeInteger(search.maxFileBytes) || search.maxFileBytes < 0) return invalid("invalid_request", "search.maxFileBytes must be a non-negative integer");
-  if (search.maxFileBytes > LIMITS.maxFileBytes) return invalid("max_file_bytes_too_large", "search.maxFileBytes is too large");
+  for (const check of [
+    validateIntegerLimit(search.maxDepth, "search.maxDepth", 0, LIMITS.maxDepth, "max_depth_too_large"),
+    validateIntegerLimit(search.maxFileBytes, "search.maxFileBytes", 0, LIMITS.maxFileBytes, "max_file_bytes_too_large"),
+    validateIntegerLimit(search.maxLineChars, "search.maxLineChars", 1, LIMITS.maxLineChars, "max_line_chars_too_large"),
+    validateIntegerLimit(search.maxFilesVisited, "search.maxFilesVisited", 1, LIMITS.maxFilesVisited, "max_files_visited_too_large"),
+    validateIntegerLimit(search.maxDirectoriesVisited, "search.maxDirectoriesVisited", 1, LIMITS.maxDirectoriesVisited, "max_directories_visited_too_large"),
+  ]) {
+    if (check) return check;
+  }
   for (const field of ["includeFileNamePatterns", "excludeFileNamePatterns", "excludeDirNamePatterns"] as const) {
     if (!isStringArray(search[field])) return invalid("invalid_request", `search.${field} must be an array of strings`);
   }
@@ -133,8 +73,8 @@ export function validateAndNormalize(request: unknown): ValidationResult {
     ["maxLineLength", "max_line_length_too_large"],
     ["maxSnippetsPerFile", "max_snippets_per_file_too_large"],
   ] as const) {
-    if (!isSafeInteger(output[field]) || output[field] < 1) return invalid("invalid_request", `output.${field} must be a positive integer`);
-    if (output[field] > LIMITS[field]) return invalid(code, `output.${field} is too large`);
+    const check = validateIntegerLimit(output[field], `output.${field}`, 1, LIMITS[field], code);
+    if (check) return check;
   }
 
   const encoding = {
@@ -172,6 +112,9 @@ export function validateAndNormalize(request: unknown): ValidationResult {
       recursive: search.recursive as boolean,
       maxDepth: search.recursive ? (search.maxDepth as number) : 0,
       maxFileBytes: search.maxFileBytes as number,
+      maxLineChars: search.maxLineChars as number,
+      maxFilesVisited: search.maxFilesVisited as number,
+      maxDirectoriesVisited: search.maxDirectoriesVisited as number,
       includeFileNamePatterns,
       excludeFileNamePatterns: [...DEFAULT_EXCLUDE_FILES, ...excludeFileNamePatterns],
       excludeDirNamePatterns: [...DEFAULT_EXCLUDE_DIRS, ...excludeDirNamePatterns],
@@ -194,6 +137,15 @@ export function validateAndNormalize(request: unknown): ValidationResult {
 
 function invalid(code: string, message: string, pathValue?: string): ValidationResult {
   return { ok: false, code, message, path: pathValue };
+}
+
+function validateIntegerLimit(value: unknown, fieldPath: string, minimum: 0 | 1, maximum: number, tooLargeCode: string): ValidationResult | null {
+  if (!isSafeInteger(value) || value < minimum) {
+    const kind = minimum === 0 ? "a non-negative integer" : "a positive integer";
+    return invalid("invalid_request", `${fieldPath} must be ${kind}`);
+  }
+  if (value > maximum) return invalid(tooLargeCode, `${fieldPath} is too large`);
+  return null;
 }
 
 function findUnknownField(value: unknown, shape: Record<string, true | Record<string, unknown>>, prefix = ""): string | null {

--- a/test/encoding-diagnostics.test.ts
+++ b/test/encoding-diagnostics.test.ts
@@ -97,6 +97,26 @@ describe("miku-grep encoding and diagnostics", () => {
     );
   });
 
+  test("does not read files through symlinks that point outside request root", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-outside-"));
+    await fs.writeFile(path.join(outside, "secret.txt"), "RepositoryMap\n", "utf8");
+    await fs.symlink(outside, path.join(root, "outside"));
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "content" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([]);
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ severity: "info", code: "symlink_skipped", path: "outside", skipped: true })]),
+    );
+  });
+
   test("reports decode errors and strips UTF-8 BOM before matching", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
     await fs.writeFile(path.join(root, "bad.txt"), Buffer.from([0xff, 0xfe, 0xfd]));

--- a/test/limits.test.ts
+++ b/test/limits.test.ts
@@ -63,4 +63,71 @@ describe("miku-grep output limits", () => {
     expect(result.summary.truncatedReason).toBe("max_matches_per_file");
     expect(result.diagnostics.filter((diagnostic) => diagnostic.code === "max_matches_per_file")).toHaveLength(2);
   });
+
+  test("stops traversal at maxFilesVisited", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "a.txt"), "RepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "b.txt"), "RepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { maxFilesVisited: 1 },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary.filesVisited).toBe(1);
+    expect(result.summary.truncated).toBe(true);
+    expect(result.summary.truncatedReason).toBe("max_files_visited");
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "max_files_visited", details: { maxFilesVisited: 1 } })]),
+    );
+  });
+
+  test("skips lines that exceed maxLineChars", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "long-line.txt"), `${"A".repeat(20)}RepositoryMap\nRepositoryMap\n`, "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { maxLineChars: 16 },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([expect.objectContaining({ file: "long-line.txt", line: 2 })]);
+    expect(result.summary.truncated).toBe(true);
+    expect(result.summary.truncatedReason).toBe("max_line_chars_exceeded");
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "max_line_chars_exceeded", file: "long-line.txt", line: 1, skipped: true })]),
+    );
+  });
+
+  test("stops traversal at maxDirectoriesVisited", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "a"), { recursive: true });
+    await fs.mkdir(path.join(root, "b"), { recursive: true });
+    await fs.writeFile(path.join(root, "a", "a.txt"), "RepositoryMap\n", "utf8");
+    await fs.writeFile(path.join(root, "b", "b.txt"), "RepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { maxDirectoriesVisited: 1 },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([]);
+    expect(result.summary.truncated).toBe(true);
+    expect(result.summary.truncatedReason).toBe("max_directories_visited");
+    expect(result.diagnostics).toEqual(
+      expect.arrayContaining([expect.objectContaining({ code: "max_directories_visited", details: { maxDirectoriesVisited: 1 } })]),
+    );
+  });
 });

--- a/test/path-security.test.ts
+++ b/test/path-security.test.ts
@@ -1,0 +1,19 @@
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { isPathInsideOrSame } from "../src/path-security.js";
+
+describe("path security helpers", () => {
+  test("accepts paths inside or equal to the base path", () => {
+    const base = path.resolve("/tmp/miku-grep-base");
+
+    expect(isPathInsideOrSame(base, base)).toBe(true);
+    expect(isPathInsideOrSame(path.join(base, "src", "file.txt"), base)).toBe(true);
+  });
+
+  test("rejects sibling paths with the same prefix", () => {
+    const base = path.resolve("/tmp/miku-grep-base");
+    const sibling = path.resolve("/tmp/miku-grep-base2/file.txt");
+
+    expect(isPathInsideOrSame(sibling, base)).toBe(false);
+  });
+});

--- a/test/regex-safety.test.ts
+++ b/test/regex-safety.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import { hasNestedQuantifiedGroup } from "../src/regex-safety.js";
+
+describe("regex safety heuristics", () => {
+  test.each([
+    ["^(a+)+$", true],
+    ["(.+)+", true],
+    ["(a*)+", true],
+    ["(a{1,3})*", true],
+    ["^([a+])+$", false],
+    ["\\(a+\\)+", false],
+    ["Repository(Map)?", false],
+  ])("detects nested quantified groups in %s", (pattern, expected) => {
+    expect(hasNestedQuantifiedGroup(pattern)).toBe(expected);
+  });
+});

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -21,6 +21,9 @@ describe("miku-grep request validation", () => {
       "recursive",
       "maxDepth",
       "maxFileBytes",
+      "maxLineChars",
+      "maxFilesVisited",
+      "maxDirectoriesVisited",
       "includeFileNamePatterns",
       "excludeFileNamePatterns",
       "excludeDirNamePatterns",
@@ -38,6 +41,9 @@ describe("miku-grep request validation", () => {
       recursive: true,
       maxDepth: 20,
       maxFileBytes: 10485760,
+      maxLineChars: 1000000,
+      maxFilesVisited: 100000,
+      maxDirectoriesVisited: 10000,
       includeFileNamePatterns: [],
     });
     expect(result.effectiveRequest.search.excludeFileNamePatterns).toEqual(
@@ -148,12 +154,42 @@ describe("miku-grep request validation", () => {
     expect(tooManyMatches.error?.code).toBe("max_matches_too_large");
   });
 
+  test("rejects oversized and nested quantified regex patterns", async () => {
+    const root = await fixture();
+    const tooLarge = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "a".repeat(1001) },
+    });
+    const unsafe = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "^(a+)+$" },
+    });
+    const charClassPlus = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "^([a+])+$" },
+    });
+
+    expect(tooLarge.ok).toBe(false);
+    expect(tooLarge.error?.code).toBe("regex_too_large");
+    expect(unsafe.ok).toBe(false);
+    expect(unsafe.error?.code).toBe("unsafe_regex");
+    expect(charClassPlus.ok).toBe(true);
+  });
+
   test.each([
     ["invalid_version", (root: string) => ({ ...baseRequest(root), version: 2 })],
     ["invalid_query_type", (root: string) => ({ ...baseRequest(root), query: { type: "glob", text: "RepositoryMap" } })],
     ["invalid_search_target", (root: string) => ({ ...baseRequest(root), search: { target: "path" } })],
     ["invalid_output_mode", (root: string) => ({ ...baseRequest(root), output: { mode: "raw" } })],
+    ["regex_too_large", (root: string) => ({ ...baseRequest(root), query: { type: "regex", text: "a".repeat(1001) } })],
+    ["unsafe_regex", (root: string) => ({ ...baseRequest(root), query: { type: "regex", text: "^(a+)+$" } })],
     ["max_depth_too_large", (root: string) => ({ ...baseRequest(root), search: { maxDepth: 51 } })],
+    ["max_line_chars_too_large", (root: string) => ({ ...baseRequest(root), search: { maxLineChars: 10000001 } })],
+    ["max_files_visited_too_large", (root: string) => ({ ...baseRequest(root), search: { maxFilesVisited: 1000001 } })],
+    ["max_directories_visited_too_large", (root: string) => ({ ...baseRequest(root), search: { maxDirectoriesVisited: 100001 } })],
     ["max_line_length_too_large", (root: string) => ({ ...baseRequest(root), output: { maxLineLength: 4001 } })],
     ["max_snippets_per_file_too_large", (root: string) => ({ ...baseRequest(root), output: { maxSnippetsPerFile: 101 } })],
     ["max_file_bytes_too_large", (root: string) => ({ ...baseRequest(root), search: { maxFileBytes: 104857601 } })],


### PR DESCRIPTION
## 概要

`miku-grep` の検索処理に対して、正規表現・探索範囲・入力行長・root 境界に関する安全対策を追加します。あわせて、CLI 仕様、ヘルプ、README、セキュリティ文書、テストを更新します。

## 主な変更

- request contract を `request-contract.ts` に分離し、default 値・limit 値・request shape を集約
- `search.maxLineChars`、`search.maxFilesVisited`、`search.maxDirectoriesVisited` を追加
- regex pattern length 上限と nested quantified group の検出を追加
- root の realpath を検索境界として扱い、探索中の path が root 外へ解決された場合に skip
- symlink skip と root escape 対策を強化
- 長すぎる行を `max_line_chars_exceeded` diagnostic として skip
- traversal limit 到達時に `max_files_visited` / `max_directories_visited` diagnostic を返す
- CLI help、README、CLI spec に新しい limit・diagnostic・security behavior を反映
- `docs/miku-grep-security.md` を追加し、現時点の対策と残リスクを整理

## テスト

以下の観点のテストが追加・更新されています。

- regex safety heuristic
- path security helper
- traversal limit
- long line skip
- validation error code
- symlink / root escape 関連 diagnostic
- effectiveRequest default key order