### PR TITLE
miku-grep のバージョンを 0.5.0 に更新し、npm publish を将来課題として記録する

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -156,6 +156,10 @@
 - [x] README public path hygiene
   - 実装: README の CLI specification link を repository-relative path に修正。
 
+- [ ] npm publish
+  - 方針: 当面の配布は GitHub Release のみとし、npm publish は遠い未来の検討事項とする。
+  - 実施時の確認候補: package name / ownership、npm provenance、2FA、publish access、README の npm install 手順、release workflow。
+
 - [x] package dry-run
   - 確認: `npm_config_cache=.npm-cache npm pack --dry-run` で package contents を確認。
   - 補足: default npm cache は local environment の権限問題で失敗したため、workspace-local cache を指定して確認した。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-grep",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-grep",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "iconv-lite": "^0.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-grep",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "Local-first structured grep CLI for AI agents and automation.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## 概要

この PR では、`miku-grep` の package version を `0.5.0` に更新します。

あわせて、当面の配布方針を GitHub Release のみとし、`npm publish` は遠い未来の検討事項として `TODO.md` に追記します。

## 変更内容

- `package.json` の version を `0.1.0` から `0.5.0` に更新
- `package-lock.json` の version を `0.1.0` から `0.5.0` に更新
- `TODO.md` に `npm publish` を未完了項目として追加
  - 当面の配布は GitHub Release のみ
  - npm publish は遠い未来の検討事項
  - 実施時の確認候補として、package name / ownership、npm provenance、2FA、publish access、README の npm install 手順、release workflow を記載

## 確認事項

- 指定コミットで変更されたファイルは以下です。
  - `package.json`
  - `package-lock.json`
  - `TODO.md`

## テスト

未確認