### PR TITLE
CLI bundle を GitHub Release に添付する workflow を追加

### DIFF
--- a/.github/workflows/release-cli-bundle.yml
+++ b/.github/workflows/release-cli-bundle.yml
@@ -1,0 +1,71 @@
+name: Release CLI bundle
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "GitHub Release tag to attach the CLI bundle to"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  release-cli-bundle:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.release.tag_name || github.event.inputs.tag_name, 'v')
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Prepare release assets
+        env:
+          TAG_NAME: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG_NAME#v}"
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          case "${VERSION}" in
+            "${PACKAGE_VERSION}"|"${PACKAGE_VERSION}".*) ;;
+            *)
+              echo "Release tag version (${VERSION}) must match package.json version (${PACKAGE_VERSION}) or add a dot suffix such as ${PACKAGE_VERSION}.2." >&2
+              exit 1
+              ;;
+          esac
+
+          mkdir -p release-assets
+          cp bundle/miku-grep.mjs "release-assets/miku-grep-${VERSION}.mjs"
+          cp bundle/miku-grep-sources.tgz "release-assets/miku-grep-sources-${VERSION}.tgz"
+
+      - name: Verify CLI bundle asset
+        run: npm run smoke:bundle
+
+      - name: Upload CLI bundle to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag_name || github.event.release.tag_name || github.ref_name }}
+          files: release-assets/*
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## 概要

GitHub Release 向けに CLI bundle をビルドし、release asset としてアップロードする workflow を追加します。

## 変更内容

- `.github/workflows/release-cli-bundle.yml` を追加
- GitHub Release の `published` イベントで workflow を実行
- `workflow_dispatch` から `tag_name` を指定して手動実行できるように追加
- Node.js 20 で `npm ci` と `npm run build` を実行
- `bundle/miku-grep.mjs` を `miku-grep-<version>.mjs` として release asset 化
- `bundle/miku-grep-sources.tgz` を `miku-grep-sources-<version>.tgz` として release asset 化
- release tag の version が `package.json` の version と一致する、または dot suffix 付きであることを確認
- `npm run smoke:bundle` で bundle smoke test を実行
- `softprops/action-gh-release@v2` で release asset をアップロード

## 補足

- 対象 commit では workflow ファイルを新規追加しています。
- 変更ファイルは `.github/workflows/release-cli-bundle.yml` のみです。

## 確認

- このセッションで `npm run smoke:bundle` を実行し、成功しています。