### PR TITLE
デフォルト除外パターンをリクエスト指定で置き換え可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ traversal の resource limit として、`search.maxFilesVisited` の default �
 
 include / exclude は glob pattern です。`query.type: "regex"` は検索語の解釈だけを切り替えます。
 
-MVP では default exclude preset を常に適用し、無効化 option は持ちません。`.git`、`.svn`、`node_modules`、`target`、`build`、`dist`、`.gradle`、`.idea`、`.vscode`、`.settings`、`vendor` などを既定で除外します。
+MVP では `search.excludeFileNamePatterns` と `search.excludeDirNamePatterns` が未指定の場合に default exclude preset を適用します。`.git`、`.svn`、`node_modules`、`target`、`build`、`dist`、`.gradle`、`.idea`、`.vscode`、`.settings`、`vendor` などを既定で除外します。
+
+`search.excludeFileNamePatterns` または `search.excludeDirNamePatterns` を指定した場合、その配列は対応する default exclude preset を置き換えます。空配列 `[]` は、その種別の除外なしを意味します。
 
 ## encoding 方針
 

--- a/TODO.md
+++ b/TODO.md
@@ -64,8 +64,8 @@
 
 - [x] empty arrays
   - 決定: `includeFileNamePatterns` missing or `[]` は include 制限なし。
-  - 決定: `excludeFileNamePatterns` missing or `[]` は default exclude preset のみ。
-  - 決定: `excludeDirNamePatterns` missing or `[]` は default exclude preset のみ。
+  - 決定: `excludeFileNamePatterns` missing は default exclude preset、指定ありは default exclude preset の置き換え、`[]` は file name 除外なし。
+  - 決定: `excludeDirNamePatterns` missing は default exclude preset、指定ありは default exclude preset の置き換え、`[]` は directory name 除外なし。
 
 ## implementation preflight decisions
 

--- a/docs/miku-grep-cli-spec.md
+++ b/docs/miku-grep-cli-spec.md
@@ -318,15 +318,19 @@ Glob matching does not cross path separators.
 
 Path-level include / exclude, such as `includePathPatterns` or `excludePathPatterns`, is outside MVP.
 
-MVP always applies the default exclude preset. There is no option to disable it.
+MVP applies the default exclude preset when `excludeFileNamePatterns` or `excludeDirNamePatterns` is omitted.
 
-Request `excludeFileNamePatterns` and `excludeDirNamePatterns` are additional excludes.
+Request `excludeFileNamePatterns` and `excludeDirNamePatterns` replace the corresponding default exclude preset when specified.
 
 Missing or empty `includeFileNamePatterns` means no include restriction.
 
-Missing or empty `excludeFileNamePatterns` means no request-level file exclude beyond the default exclude preset.
+Missing `excludeFileNamePatterns` means the default file exclude preset is used.
 
-Missing or empty `excludeDirNamePatterns` means no request-level directory exclude beyond the default exclude preset.
+Empty `excludeFileNamePatterns` means no file name excludes.
+
+Missing `excludeDirNamePatterns` means the default directory exclude preset is used.
+
+Empty `excludeDirNamePatterns` means no directory name excludes.
 
 Default exclude dir names:
 
@@ -363,8 +367,8 @@ Include / exclude priority:
 
 ```text
 1. If includeFileNamePatterns is specified, only matching files remain candidates.
-2. Default exclude preset is applied.
-3. Request excludeFileNamePatterns and excludeDirNamePatterns are applied.
+2. Effective excludeDirNamePatterns is applied to directory basenames.
+3. Effective excludeFileNamePatterns is applied to file basenames.
 ```
 
 ### dotfiles
@@ -448,10 +452,9 @@ Example:
 
 ## Binary Files
 
-MVP treats files as binary when either of the following is true.
+MVP treats files as binary when the file content contains a NUL byte during content search.
 
-- The file matches the default binary-like exclude file name patterns, such as `*.class`, `*.jar`, `*.zip`, `*.png`, `*.jpg`, `*.jpeg`, `*.gif`, or `*.pdf`
-- The file content contains a NUL byte during content search
+The default file exclude preset excludes common binary-like file name patterns, such as `*.class`, `*.jar`, `*.zip`, `*.png`, `*.jpg`, `*.jpeg`, `*.gif`, and `*.pdf`, before content scanning unless `excludeFileNamePatterns` is specified and replaces that preset.
 
 Binary files are not searched in `content` mode.
 
@@ -545,8 +548,8 @@ Successful result example:
       "maxFilesVisited": 100000,
       "maxDirectoriesVisited": 10000,
       "includeFileNamePatterns": ["*.java", "*.md"],
-      "excludeFileNamePatterns": ["*.class", "*.jar", "*.zip", "*.png", "*.jpg", "*.jpeg", "*.gif", "*.pdf", ".classpath", ".project", "*.generated.md"],
-      "excludeDirNamePatterns": [".git", ".svn", "node_modules", "target", "build", "dist", ".gradle", ".idea", ".vscode", ".settings", "vendor", "tmp"]
+      "excludeFileNamePatterns": ["*.generated.md"],
+      "excludeDirNamePatterns": ["tmp"]
     },
     "output": {
       "mode": "detail",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-grep",
-  "version": "0.5.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-grep",
-      "version": "0.5.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "iconv-lite": "^0.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-grep",
-  "version": "0.5.0",
+  "version": "0.8.1",
   "description": "Local-first structured grep CLI for AI agents and automation.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/help.ts
+++ b/src/help.ts
@@ -70,12 +70,14 @@ REQUEST FIELDS
     MVP glob supports "*" and "?" within one basename.
 
   search.excludeFileNamePatterns
-    Optional additional basename glob excludes.
-    Default excludes are always applied.
+    Optional basename glob excludes.
+    When omitted, default excludes are used.
+    When specified, this value replaces default excludes.
 
   search.excludeDirNamePatterns
-    Optional additional directory basename glob excludes.
-    Default excludes are always applied.
+    Optional directory basename glob excludes.
+    When omitted, default excludes are used.
+    When specified, this value replaces default excludes.
 
   output.mode
     "file-summary" or "detail". Default: "file-summary".

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -32,6 +32,8 @@ export function validateAndNormalize(request: unknown): ValidationResult {
     return invalid("invalid_request", "search, output, and encoding must be objects when specified");
   }
 
+  const hasExcludeFileNamePatterns = hasOwn(searchInput, "excludeFileNamePatterns");
+  const hasExcludeDirNamePatterns = hasOwn(searchInput, "excludeDirNamePatterns");
   const search = {
     target: typeof searchInput.target === "string" ? searchInput.target : DEFAULTS.search.target,
     recursive: searchInput.recursive ?? DEFAULTS.search.recursive,
@@ -41,8 +43,8 @@ export function validateAndNormalize(request: unknown): ValidationResult {
     maxFilesVisited: searchInput.maxFilesVisited ?? DEFAULTS.search.maxFilesVisited,
     maxDirectoriesVisited: searchInput.maxDirectoriesVisited ?? DEFAULTS.search.maxDirectoriesVisited,
     includeFileNamePatterns: searchInput.includeFileNamePatterns ?? [],
-    excludeFileNamePatterns: searchInput.excludeFileNamePatterns ?? [],
-    excludeDirNamePatterns: searchInput.excludeDirNamePatterns ?? [],
+    excludeFileNamePatterns: hasExcludeFileNamePatterns ? searchInput.excludeFileNamePatterns : DEFAULT_EXCLUDE_FILES,
+    excludeDirNamePatterns: hasExcludeDirNamePatterns ? searchInput.excludeDirNamePatterns : DEFAULT_EXCLUDE_DIRS,
   };
   if (!["content", "filename", "both"].includes(search.target)) return invalid("invalid_search_target", "search.target must be content, filename, or both");
   if (typeof search.recursive !== "boolean") return invalid("invalid_request", "search.recursive must be boolean");
@@ -116,8 +118,8 @@ export function validateAndNormalize(request: unknown): ValidationResult {
       maxFilesVisited: search.maxFilesVisited as number,
       maxDirectoriesVisited: search.maxDirectoriesVisited as number,
       includeFileNamePatterns,
-      excludeFileNamePatterns: [...DEFAULT_EXCLUDE_FILES, ...excludeFileNamePatterns],
-      excludeDirNamePatterns: [...DEFAULT_EXCLUDE_DIRS, ...excludeDirNamePatterns],
+      excludeFileNamePatterns,
+      excludeDirNamePatterns,
     },
     output: {
       mode: output.mode as EffectiveRequest["output"]["mode"],
@@ -162,6 +164,10 @@ function findUnknownField(value: unknown, shape: Record<string, true | Record<st
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasOwn(value: Record<string, unknown>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
 }
 
 function isSafeInteger(value: unknown): value is number {

--- a/test/search-content.test.ts
+++ b/test/search-content.test.ts
@@ -106,6 +106,42 @@ describe("miku-grep content search", () => {
     expect(nonRecursive.effectiveRequest.search.maxDepth).toBe(0);
   });
 
+  test("can include default-excluded directories when exclude directory patterns are empty", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "node_modules", "pkg"), { recursive: true });
+    await fs.writeFile(path.join(root, "node_modules", "pkg", "index.txt"), "RepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "content", excludeDirNamePatterns: [] },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.effectiveRequest.search.excludeDirNamePatterns).toEqual([]);
+    expect(result.matches).toEqual([expect.objectContaining({ file: "node_modules/pkg/index.txt" })]);
+  });
+
+  test("omitted exclude directory patterns keep default node_modules exclusion", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "node_modules", "pkg"), { recursive: true });
+    await fs.writeFile(path.join(root, "node_modules", "pkg", "index.txt"), "RepositoryMap\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { target: "content" },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.effectiveRequest.search.excludeDirNamePatterns).toContain("node_modules");
+    expect(result.matches).toEqual([]);
+  });
+
   test("applies maxDepth to recursive traversal", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
     await fs.mkdir(path.join(root, "a", "b"), { recursive: true });

--- a/test/search-filename.test.ts
+++ b/test/search-filename.test.ts
@@ -105,6 +105,47 @@ describe("miku-grep filename and combined search", () => {
     expect(includeDoesNotMatchPath.summary.filesScanned).toBe(0);
   });
 
+  test("can include default-excluded zip files when exclude file patterns are empty", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "artifact.zip"), "not read for filename search\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "\\.zip$" },
+      search: {
+        target: "filename",
+        includeFileNamePatterns: ["*.zip"],
+        excludeFileNamePatterns: [],
+      },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.effectiveRequest.search.excludeFileNamePatterns).toEqual([]);
+    expect(result.matches).toEqual([{ type: "filename", file: "artifact.zip", matchedText: ".zip" }]);
+  });
+
+  test("omitted exclude file patterns keep default zip exclusion", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "artifact.zip"), "not read for filename search\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "\\.zip$" },
+      search: {
+        target: "filename",
+        includeFileNamePatterns: ["*.zip"],
+      },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.effectiveRequest.search.excludeFileNamePatterns).toContain("*.zip");
+    expect(result.matches).toEqual([]);
+  });
+
   test("filename-only search does not read undecodable file contents", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
     await fs.writeFile(path.join(root, "bad-name.txt"), Buffer.from([0xff, 0xfe, 0xfd]));

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -75,6 +75,32 @@ describe("miku-grep request validation", () => {
     expect(result.error?.code).toBe("unknown_field");
   });
 
+  test("uses request exclude file patterns as replacement for default excludes", async () => {
+    const root = await fixture();
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { excludeFileNamePatterns: [] },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.effectiveRequest.search.excludeFileNamePatterns).toEqual([]);
+  });
+
+  test("uses request exclude directory patterns as replacement for default excludes", async () => {
+    const root = await fixture();
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+      search: { excludeDirNamePatterns: [] },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.effectiveRequest.search.excludeDirNamePatterns).toEqual([]);
+  });
+
   test.each([
     ["non-object request", null, "invalid_request"],
     ["non-object search", (root: string) => ({ ...baseRequest(root), search: [] }), "invalid_request"],
@@ -83,6 +109,8 @@ describe("miku-grep request validation", () => {
     ["non-string include pattern", (root: string) => ({ ...baseRequest(root), search: { includeFileNamePatterns: ["*.txt", 1] } }), "invalid_request"],
     ["non-string exclude file pattern", (root: string) => ({ ...baseRequest(root), search: { excludeFileNamePatterns: [false] } }), "invalid_request"],
     ["non-string exclude dir pattern", (root: string) => ({ ...baseRequest(root), search: { excludeDirNamePatterns: [{}] } }), "invalid_request"],
+    ["null exclude file pattern", (root: string) => ({ ...baseRequest(root), search: { excludeFileNamePatterns: null } }), "invalid_request"],
+    ["null exclude dir pattern", (root: string) => ({ ...baseRequest(root), search: { excludeDirNamePatterns: null } }), "invalid_request"],
     ["unknown encoding rule field", (root: string) => ({ ...baseRequest(root), encoding: { rules: [{ fileNamePattern: "*.txt", encoding: "utf-8", extra: true }] } }), "unknown_field"],
   ])("rejects invalid request shape: %s", async (_caseName, createRequest, expectedCode) => {
     const root = await fixture();


### PR DESCRIPTION
## 概要

`search.excludeFileNamePatterns` と `search.excludeDirNamePatterns` の扱いを変更し、リクエストで指定された場合は default exclude preset への追加ではなく、対応する default exclude preset の置き換えとして扱うようにします。

あわせて、パッケージバージョンを `0.8.1` に更新します。

## 変更内容

- `excludeFileNamePatterns` / `excludeDirNamePatterns` が未指定の場合は、従来どおり default exclude preset を使用
- `excludeFileNamePatterns` / `excludeDirNamePatterns` が指定された場合は、指定配列で default exclude preset を置き換え
- 空配列 `[]` を指定した場合は、その種別の除外なしとして扱う
- `null` 指定は `invalid_request` として扱う
- README、CLI spec、CLI help、TODO の説明を新仕様に更新
- `*.zip` と `node_modules` の未指定時除外 / 空配列指定時の除外解除をテストで追加
- `package.json` / `package-lock.json` のバージョンを `0.8.1` に更新

## テスト

- `npm run test`
- 8 test files / 84 tests passed