### PR TITLE
Nodeランタイムの結果ソート順をJava互換の決定的順序に修正

### DIFF
--- a/docs/miku-grep-cli-spec.md
+++ b/docs/miku-grep-cli-spec.md
@@ -993,6 +993,8 @@ MVP output should be stable.
 
 File traversal and matched files are sorted by request.root-relative file path ascending where practical.
 
+All path and diagnostic-code string ordering uses deterministic UTF-16 code unit order, equivalent to Java `String.compareTo`, and must not use locale-aware collation.
+
 Content hits are sorted by line ascending within each file.
 
 When `search.target: "both"` produces both filename and content hits for the same file in `detail` mode, filename hits should appear before content hits for that file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-grep",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-grep",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "iconv-lite": "^0.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-grep",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Local-first structured grep CLI for AI agents and automation.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/result.ts
+++ b/src/result.ts
@@ -1,4 +1,5 @@
 import type { DetailMatch, Diagnostic, EffectiveRequest, FileSummaryMatch, MikuGrepResult, Summary } from "./public-types.js";
+import { compareStrings } from "./string-order.js";
 import { VERSION } from "./validation.js";
 
 export function createSummary(): Summary {
@@ -34,5 +35,5 @@ export function finish(
 }
 
 function sortDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
-  return diagnostics.sort((a, b) => (a.file ?? a.path ?? "").localeCompare(b.file ?? b.path ?? "") || ((a.line ?? 0) - (b.line ?? 0)) || a.code.localeCompare(b.code));
+  return diagnostics.sort((a, b) => compareStrings(a.file ?? a.path ?? "", b.file ?? b.path ?? "") || ((a.line ?? 0) - (b.line ?? 0)) || compareStrings(a.code, b.code));
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -4,6 +4,7 @@ import iconv from "iconv-lite";
 import { globMatch, matchesAny, pathGlobMatch } from "./glob.js";
 import { isPathInsideOrSame } from "./path-security.js";
 import { createSummary } from "./result.js";
+import { compareStrings } from "./string-order.js";
 import type { SearchResult, SearchState } from "./internal-types.js";
 import type {
   DetailMatch,
@@ -54,7 +55,7 @@ async function traverse(state: SearchState, absoluteDir: string, relativeDir: st
     state.diagnostics.push({ severity: "warning", code: "directory_not_readable", message: "directory could not be read and was skipped", path: relativeDir || ".", skipped: true });
     return;
   }
-  entries.sort((a, b) => a.name.localeCompare(b.name));
+  entries.sort((a, b) => compareStrings(a.name, b.name));
   for (const entry of entries) {
     if (state.globalLimitReached) return;
     const relativePath = relativeDir ? `${relativeDir}/${entry.name}` : entry.name;
@@ -259,13 +260,13 @@ function markTruncated(state: SearchState, reason: string, message: string, deta
 
 function buildDetailMatches(state: SearchState): DetailMatch[] {
   return [...state.detailsByFile.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
+    .sort(([a], [b]) => compareStrings(a, b))
     .flatMap(([, hits]) => hits.sort((a, b) => typeRank(a.type) - typeRank(b.type) || ((a.type === "content" ? a.line : 0) - (b.type === "content" ? b.line : 0)) || ((a.type === "content" ? a.column : 0) - (b.type === "content" ? b.column : 0))));
 }
 
 function buildFileSummaryMatches(state: SearchState): FileSummaryMatch[] {
   return [...state.summariesByFile.values()]
-    .sort((a, b) => a.file.localeCompare(b.file))
+    .sort((a, b) => compareStrings(a.file, b.file))
     .map((item) => ({ ...item, lines: item.lines.sort((a, b) => a - b) }));
 }
 

--- a/src/string-order.ts
+++ b/src/string-order.ts
@@ -1,0 +1,3 @@
+export function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/test/encoding-diagnostics.test.ts
+++ b/test/encoding-diagnostics.test.ts
@@ -153,6 +153,24 @@ describe("miku-grep encoding and diagnostics", () => {
     expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(["symlink_skipped", "decode_error"]);
   });
 
+  test("sorts diagnostics paths by deterministic code-unit order", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "docs"), { recursive: true });
+    await fs.writeFile(path.join(root, "README-bad.txt"), Buffer.from([0xff, 0xfe, 0xfd]));
+    await fs.writeFile(path.join(root, "target.txt"), "RepositoryMap\n", "utf8");
+    await fs.symlink(path.join(root, "target.txt"), path.join(root, "docs", "link.txt"));
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "literal", text: "RepositoryMap" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.file ?? diagnostic.path)).toEqual(["README-bad.txt", "docs/link.txt"]);
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(["decode_error", "symlink_skipped"]);
+  });
+
   test("gives pathPattern encoding rules priority over fileNamePattern rules", async () => {
     const root = await fixture();
     const result = await runRequest({

--- a/test/search-filename.test.ts
+++ b/test/search-filename.test.ts
@@ -45,6 +45,59 @@ describe("miku-grep filename and combined search", () => {
     ]);
   });
 
+  test("sorts file-summary paths by deterministic code-unit order", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "docs"), { recursive: true });
+    await fs.writeFile(path.join(root, "README.md"), "readme\n", "utf8");
+    await fs.writeFile(path.join(root, "docs", "development.md"), "development\n", "utf8");
+    await fs.writeFile(path.join(root, "docs", "cli-json-parity.md"), "parity\n", "utf8");
+    await fs.writeFile(path.join(root, "docs", "miku-grep-cli-spec.md"), "spec\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "\\.md$" },
+      search: {
+        target: "filename",
+        recursive: true,
+        maxDepth: 8,
+      },
+      output: {
+        mode: "file-summary",
+        maxMatches: 10000,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches.map((match) => match.file)).toEqual([
+      "README.md",
+      "docs/cli-json-parity.md",
+      "docs/development.md",
+      "docs/miku-grep-cli-spec.md",
+    ]);
+  });
+
+  test("sorts detail paths by deterministic code-unit order", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "docs"), { recursive: true });
+    await fs.writeFile(path.join(root, "README.md"), "readme\n", "utf8");
+    await fs.writeFile(path.join(root, "docs", "development.md"), "development\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "\\.md$" },
+      search: { target: "filename" },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([
+      { type: "filename", file: "README.md", matchedText: ".md" },
+      { type: "filename", file: "docs/development.md", matchedText: ".md" },
+    ]);
+  });
+
   test("aggregates filename and content hits in file-summary mode", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
     await fs.mkdir(path.join(root, "src"), { recursive: true });


### PR DESCRIPTION
## 概要

Nodeランタイムの文字列ソートで `localeCompare` を使っていた箇所を、UTF-16 code unit order による決定的な比較へ変更します。

これにより、ファイルパスや diagnostics code の順序が locale-aware collation に依存しないようになり、Java `String.compareTo` 相当の順序に揃います。

## 変更内容

- `compareStrings` を追加し、文字列比較を共通化
- directory entry sorting で `compareStrings` を使用
- detail match の file sorting で `compareStrings` を使用
- file-summary match の file sorting で `compareStrings` を使用
- diagnostics sorting の path/file および code 比較で `compareStrings` を使用
- CLI仕様に、path と diagnostic-code の文字列順序は Java `String.compareTo` 相当の UTF-16 code unit order とし、locale-aware collation を使わないことを明記
- `README.md` が `docs/...` より前に並ぶことを確認する filename search の回帰テストを追加
- diagnostics path でも同じ決定的順序になることを確認する回帰テストを追加
- package version を `0.8.1` から `0.8.2` に更新

## 確認

- `npm run test`
  - Test Files: 8 passed
  - Tests: 87 passed