### PR TITLE
READMEを利用者向け入口に再整理し、別プロダクト候補メモを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,78 +2,35 @@
 
 `miku-grep` は、生成AI agent と automation が repository やディレクトリ内で「読むべきファイル」を見つけるための local-first 検索 CLI です。
 
-通常の `grep` の代わりに、検索結果、summary、diagnostics を JSON として返します。
+通常の `grep` の代わりに、検索結果、summary、diagnostics を JSON として返します。人間が画面で読む検索結果ではなく、次の処理に渡しやすい structured result を得るための tool です。
 
 厳格な CLI / JSON 仕様は [docs/miku-grep-cli-spec.md](docs/miku-grep-cli-spec.md) を参照してください。
 
 セキュリティに関する調査結果と対策は [docs/miku-grep-security.md](docs/miku-grep-security.md) を参照してください。
 
-## 背景
+## 何に使うか
 
-生成AI agent と repository を扱っていると、通常の grep だけでは足りない場面があります。
+`miku-grep` は、生成AI agent や script が local repository を読む前に、候補 file を絞り込むために使います。
 
-特に重要なのは「何を読むべきか」を見つけることです。単なる文字列検索だけでなく、ディレクトリ構造、除外ルール、encoding、検索結果の形式、diagnostics を考慮した検索 tool が必要です。
+主な用途:
 
-まずは MCP ではなく CLI として作ります。将来的に Agent Skills から呼び出せる形にします。
+- file content から読むべき file を探す
+- file path / file name から候補を探す
+- content と filename の両方を同じ request で探す
+- result JSON の `summary` と `diagnostics` を見て、検索範囲や skipped file を判断する
+- `file-summary` で候補 file を絞ってから、必要に応じて `detail` で snippet を読む
 
-## 対象
+`miku-grep` は semantic search ではありません。embedding search、意味による ranking、Git repository root の自動検出は行いません。
 
-`miku-grep` の対象は grep 代替の repository / directory 検索 CLI です。
+## すぐ使う
 
-意味あり retrieve tool は対象外です。embedding search、semantic ranking、Git repository root の自動検出は行いません。
-
-## MVP
-
-現在の Node CLI MVP 実装では次を扱います。
-
-- Node CLI
-- stdin JSON 入力
-- stdout JSON 出力
-- `content` / `filename` / `both`
-- `literal` / `regex`
-- glob-based include / exclude
-- default exclude preset
-- recursive / maxDepth default
-- `utf-8` / `shift_jis`
-- encoding rules
-- diagnostics
-- `detail` / `file-summary`
-- `--version`
-- `--help`
-
-`--help` は生成AI agent がそれだけを読んで request JSON を組み立てられるよう、stdin / stdout contract、request field、default、limit、result shape、diagnostic code、完全な stdin / stdout 例を含めています。
-
-## CLI の基本形
-
-stdin で request JSON を受け取り、stdout に result JSON を返します。
+stdin で request JSON を渡し、stdout から result JSON を受け取ります。
 
 ```bash
 miku-grep < request.json > result.json
 ```
 
-stderr は progress、verbose log、予期しない runtime-level message など、JSON result と混ぜたくない補助情報だけに使います。
-
-request JSON と result JSON はどちらも top-level に `version: 1` を持ちます。
-
-request JSON の未知 field は validation error とします。
-
-stdout の result JSON は 2-space indent で整形して出力します。
-
-runtime artifact の smoke test 用に、`--version` は stdin JSON なしで実行できます。
-
-```bash
-miku-grep --version
-```
-
-生成AI agent や automation がコマンド仕様を把握するために、`--help` も stdin JSON なしで実行できます。
-
-```bash
-miku-grep --help
-```
-
-`--help` は stdin / stdout contract、request field、default、limit、result shape、diagnostic code、完全な stdin / stdout 例、実行例を stdout に出力します。
-
-## 最小 request 例
+最小 request 例:
 
 ```json
 {
@@ -84,14 +41,172 @@ miku-grep --help
     "text": "RepositoryMap"
   },
   "search": {
-    "target": "content",
-    "recursive": true,
-    "maxDepth": 8
+    "target": "content"
   }
 }
 ```
 
-## result の基本形
+`root` が相対 path の場合、CLI process の current working directory から解決されます。`miku-grep` は Git repository root を自動検出しないため、検索したい directory を `root` に指定してください。
+
+`--version` と `--help` は stdin JSON なしで実行できます。
+
+```bash
+miku-grep --version
+miku-grep --help
+```
+
+`--help` は、生成AI agent や automation が request JSON を組み立てるために必要な stdin / stdout contract、request field、default、result shape、diagnostics、例を stdout に出力します。
+
+## よく使う request
+
+### file content を検索する
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "query": {
+    "type": "literal",
+    "text": "diagnostics"
+  },
+  "search": {
+    "target": "content"
+  }
+}
+```
+
+### filename を検索する
+
+`filename` は basename だけでなく、`root` からの相対 file path を検索します。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "query": {
+    "type": "literal",
+    "text": "security"
+  },
+  "search": {
+    "target": "filename"
+  }
+}
+```
+
+### filename と content の両方を検索する
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "query": {
+    "type": "literal",
+    "text": "encoding"
+  },
+  "search": {
+    "target": "both"
+  }
+}
+```
+
+### 対象 file を絞る
+
+include / exclude は glob pattern です。`query.type: "regex"` は検索語の解釈だけを切り替えます。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "query": {
+    "type": "literal",
+    "text": "effectiveRequest"
+  },
+  "search": {
+    "target": "content",
+    "includeFileNamePatterns": ["*.ts", "*.md"],
+    "excludeDirNamePatterns": [".git", "node_modules", "dist"]
+  }
+}
+```
+
+`excludeFileNamePatterns` と `excludeDirNamePatterns` が未指定の場合は default exclude preset が使われます。`.git`、`node_modules`、`target`、`build`、`dist`、`vendor` など、通常の検索で読みたくない directory は既定で除外されます。
+
+### detail 出力にする
+
+`output` 未指定時は `file-summary` です。まず候補 file を絞る用途ではこれが既定です。
+
+hit ごとの行、column、matched text が必要な場合は `detail` を指定します。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "query": {
+    "type": "literal",
+    "text": "RepositoryMap"
+  },
+  "search": {
+    "target": "content"
+  },
+  "output": {
+    "mode": "detail",
+    "maxMatches": 200,
+    "maxMatchesPerFile": 20,
+    "maxLineLength": 240
+  }
+}
+```
+
+### Shift_JIS file を検索する
+
+encoding auto detect は行いません。UTF-8 以外を読む場合は encoding rule を指定します。
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "query": {
+    "type": "literal",
+    "text": "検索語"
+  },
+  "search": {
+    "target": "content",
+    "includeFileNamePatterns": ["*.txt"]
+  },
+  "encoding": {
+    "default": "utf-8",
+    "rules": [
+      {
+        "fileNamePattern": "*.txt",
+        "encoding": "shift_jis"
+      }
+    ],
+    "onDecodeError": "skip"
+  }
+}
+```
+
+読めなかった file、binary と判定された file、size limit を超えた file などは `diagnostics` に返されます。
+
+### regex で検索する
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "query": {
+    "type": "regex",
+    "text": "Repository(Map|Index)"
+  },
+  "search": {
+    "target": "content"
+  }
+}
+```
+
+検索は case-sensitive です。`caseSensitive` や `ignoreCase` option はありません。case variation が必要な場合は regex pattern で表現してください。
+
+## result の読み方
 
 stdout の result JSON は、成功時も期待可能な失敗時も同じ top-level shape を保ちます。
 
@@ -115,108 +230,31 @@ stdout の result JSON は、成功時も期待可能な失敗時も同じ top-l
 }
 ```
 
-`output` 未指定時の default は `file-summary` です。
+主な field:
 
-```json
-{
-  "mode": "file-summary",
-  "maxMatches": 200,
-  "maxMatchesPerFile": 20,
-  "maxLineLength": 240,
-  "maxSnippetsPerFile": 3
-}
-```
+- `ok`: request が実行できたかどうか
+- `error`: `ok: false` のときの代表 error
+- `effectiveRequest`: default 適用後の実際の検索条件
+- `matches`: 検索結果。`output.mode` によって item shape が変わります
+- `summary`: scanned file 数、hit 数、truncation の有無
+- `diagnostics`: skipped file、decode error、limit 到達、validation error など
 
-output limit の最大許容値は `maxMatches: 10000`、`maxMatchesPerFile: 1000`、`maxLineLength: 4000`、`maxSnippetsPerFile: 100` です。
+`file-summary` mode の `matches[]` は、1 matched file = 1 item です。agent が次に読む file を選ぶ最初の検索に向いています。
 
-## 検索モード
+`detail` mode の `matches[]` は、1 hit = 1 item です。line、column、matched text、snippet を見たい場合に使います。
 
-```text
-content
-  ファイル内容を検索する
+## 注意点
 
-filename
-  request.root からの相対 file path を検索する
+- stdout は result JSON 専用です。progress log や runtime-level message は stderr に出します。
+- request JSON と result JSON はどちらも top-level に `version: 1` を持ちます。
+- request JSON の未知 field は validation error です。
+- result JSON 内の `file` は `root` からの相対 path です。絶対 path は返しません。
+- path separator は platform に関わらず `/` です。
+- symlink は MVP では追跡しません。
+- content 検索では file size、line length、match count などの resource limit が適用されます。
+- regex は Node.js `RegExp` を使いますが、JavaScript 固有の flags は request schema では受け取りません。
 
-both
-  filename と content の両方を検索する
-```
-
-`miku-grep` は Git repository root を自動検出しません。`request.root` を検索エントリポイントとして扱い、その範囲だけを検索します。
-
-`request.root` が相対パスの場合、CLI process の current working directory から解決します。
-
-探索中に realpath が `request.root` の realpath 外へ解決される path は skip して diagnostics に返します。
-
-result JSON 内の `file` は `request.root` からの相対パスです。絶対パスは返しません。path separator は platform に関わらず常に `/` です。
-
-`recursive: true` で `maxDepth` を省略した場合、MVP では `20` として扱います。
-
-`maxDepth` の最大許容値は `50` です。
-
-`recursive` 未指定時は `true` です。
-
-traversal の resource limit として、`search.maxFilesVisited` の default は `100000`、最大許容値は `1000000` です。`search.maxDirectoriesVisited` の default は `10000`、最大許容値は `100000` です。
-
-## 除外の基本方針
-
-include / exclude は glob pattern です。`query.type: "regex"` は検索語の解釈だけを切り替えます。
-
-MVP では `search.excludeFileNamePatterns` と `search.excludeDirNamePatterns` が未指定の場合に default exclude preset を適用します。`.git`、`.svn`、`node_modules`、`target`、`build`、`dist`、`.gradle`、`.idea`、`.vscode`、`.settings`、`vendor` などを既定で除外します。
-
-`search.excludeFileNamePatterns` または `search.excludeDirNamePatterns` を指定した場合、その配列は対応する default exclude preset を置き換えます。空配列 `[]` は、その種別の除外なしを意味します。
-
-## encoding 方針
-
-MVP では encoding auto detect / best-effort decode は行いません。
-
-```text
-推測しない
-黙って失敗しない
-適用した encoding rule を返す
-読めなかったファイルを diagnostics に返す
-```
-
-対応 encoding はまず `utf-8` と `shift_jis` です。
-
-`encoding.default` 未指定時は `utf-8`、`encoding.rules` 未指定時は `[]`、`encoding.onDecodeError` 未指定時は `skip` です。UTF-8 BOM は検索前に除去します。
-
-content 検索では `search.maxFileBytes` の default を 10 MiB とし、超過ファイルは skip して diagnostics に返します。
-
-`search.maxFileBytes` の最大許容値は 100 MiB です。
-
-decode 後の 1 行が `search.maxLineChars` を超える場合、その行は skip して diagnostics に返します。default は `1000000`、最大許容値は `10000000` です。
-
-## regex と case
-
-MVP の検索は case-sensitive です。
-
-`query.type: "literal"` は単純な substring search です。Unicode 正規化、locale 比較、case folding は行いません。
-
-`caseSensitive` や `ignoreCase` の option は持ちません。case variation が必要な場合は `query.type: "regex"` の pattern で表現します。
-
-MVP Node CLI の regex は Node.js `RegExp` を使い、content 検索では行ごとに match します。複数行 regex は MVP 外です。
-
-JavaScript 固有の regex flags は MVP では受け取りません。将来の Java CLI では regex engine が異なる可能性があるため、cross-runtime の完全同一挙動は保証しません。
-
-regex pattern text は 1000 文字以下に制限します。`(.+)+` や `(a*)+` のような nested quantified group は ReDoS リスクを避けるため validation error とします。
-
-## 詳細仕様
-
-詳細は [miku-grep CLI Specification](docs/miku-grep-cli-spec.md) にあります。
-
-主な内容:
-
-- stdin request JSON schema
-- stdout result JSON schema
-- exit code
-- `effectiveRequest`
-- `matches[]`
-- `diagnostics[]`
-- `summary`
-- default exclude preset
-- encoding policy
-- dangerous request handling
+詳細な default、limit、schema、exit code、diagnostic code、sort order は [miku-grep CLI Specification](docs/miku-grep-cli-spec.md) を参照してください。
 
 ## 開発
 
@@ -231,8 +269,6 @@ npm install
 ```bash
 npm test
 ```
-
-`npm test` は TypeScript compile 後に Vitest を実行します。現状のテストは CLI contract、request validation、検索モード、encoding、diagnostics、sort、limit、bundle前提の subprocess実行をカバーしています。
 
 TypeScript compile、テスト、単一ファイル CLI bundle 生成をまとめて実行します。
 
@@ -264,18 +300,22 @@ npm run smoke:bundle
 
 `bundle/miku-grep-sources.tgz` は再ビルド、監査、下流確認用の source archive です。
 
-npm package には、CLI実行用の `dist/`、単一ファイル runtime artifact の `bundle/`、smoke / bundle生成用の `scripts/`、`README.md`、`LICENSE` を含めます。
+## 関連ドキュメント
 
-## 後続
+- [miku-grep CLI Specification](docs/miku-grep-cli-spec.md)
+- [miku-grep Security Notes](docs/miku-grep-security.md)
+- [Miku Software Overview Design](docs/miku-soft-00-overview-design-v20260427.md)
+- [Miku Software Main Application Design](docs/miku-soft-10-mainapp-design-v20260501.md)
+- [Miku Software Agent Skills Design](docs/miku-soft-40-agentskills-design-v20260501.md)
 
-- Java CLI
-- Agent Skills から呼べる説明
-- Node.js single-file runtime artifact
-- repository map 対応
-- policy-aware search の強化
+## 関連プロジェクト
 
-## MCP について
+- Agent Skills 版: [miku-grep-skills](https://github.com/igapyon/miku-grep-skills)
+- Java 版: [miku-grep-java](https://github.com/igapyon/miku-grep-java)
 
-MCP は MVP では不要です。
+## 後続候補
 
-まず CLI と Agent Skills まででよいです。MCP は tool interface の話なので、検索器の仕様が固まってから考えます。
+- Repository map 別プロダクト候補: [Repository Map Product Candidate](docs/product-candidate-repository-map.md)
+- Policy-aware search 別プロダクト候補: [Policy-Aware Search Requirements Memo](docs/product-candidate-policy-aware-search.md)
+
+MCP adapter は当面対応しません。まずは CLI、Java 版、Agent Skills 版を通常の利用経路として扱います。

--- a/docs/product-candidate-policy-aware-search.md
+++ b/docs/product-candidate-policy-aware-search.md
@@ -1,0 +1,403 @@
+# Policy-Aware Search Requirements Memo
+
+## 目的
+
+この文書は、`miku-grep` または周辺 tool における policy-aware search 強化の要求を整理する。
+
+policy-aware search とは、単に query に match する file を返すだけでなく、検索対象 file の安全性、生成物らしさ、機密情報らしさ、agent に渡す際の注意点を policy として扱い、skip / warning / diagnostics / override guidance を構造化して返す考え方である。
+
+現時点では、この内容は `miku-grep` の正式 request schema ではない。将来検討のための要求メモとして扱う。
+
+## 背景
+
+生成AI agent や automation が repository を検索するとき、検索 hit だけを返すと次のような問題が起きる。
+
+- `.env` や秘密鍵など、読ませるべきでない file が検索対象になる
+- generated file や build output が大量に hit し、本来読むべき source file が埋もれる
+- lock file や minified file など、agent が読む価値の低い file が token budget を消費する
+- prompt injection を含む可能性のある文書を、agent が命令として扱ってしまう
+- なぜ file が skip されたか、どう override すれば読めるかが result から分からない
+
+既存の `miku-grep` は default exclude preset、root realpath 境界、symlink skip、file size limit、binary skip、decode diagnostics などの基礎的な safety を持つ。
+
+policy-aware search は、これらをより明示的な policy として整理し、agent / automation が検索結果を安全に扱いやすくする方向である。
+
+## 対象
+
+扱う policy 候補:
+
+- secret-looking file policy
+- credential-looking file policy
+- generated file policy
+- dependency / build output policy
+- lock file policy
+- binary / large file policy
+- prompt-injection-risk policy
+- allowlist / denylist policy
+- automation-safe preset
+- override guidance
+
+扱わないもの:
+
+- 完全な secret scanning
+- DLP 製品相当の検出
+- malware scanning
+- content moderation
+- LLM による file safety 判定
+- remote policy service への問い合わせ
+- repository の権限管理
+
+## 現行 `miku-grep` との関係
+
+現行 `miku-grep` に既にある safety / policy 的な挙動:
+
+- default exclude preset
+- root が広すぎる場合の拒否
+- root realpath 境界外への path escape skip
+- symlink skip
+- max file size
+- max line chars
+- binary file skip
+- decode error diagnostics
+- regex pattern length limit
+- unsafe regex heuristic reject
+- output match limit
+
+policy-aware search は、これを次の方向に拡張する候補である。
+
+- policy preset を request で選べる
+- skip ではなく warning として返す policy を選べる
+- policy による判断理由を diagnostics に明示する
+- override するための request field を明示する
+- agent 向けに「読んでよい / 注意して読む / 読まない」を区別する
+
+## policy preset 案
+
+### default
+
+通常の `miku-grep` default に近い preset。
+
+目的:
+
+- grep 代替として自然に使う
+- `.git`、`node_modules`、`dist` などのノイズを避ける
+- 機密らしい file は warning か skip の候補にする
+
+### safe-agent-default
+
+生成AI agent / automation 向けの保守的な preset。
+
+目的:
+
+- secret-looking file を原則 skip
+- dependency / build output を原則 skip
+- generated file を warning または skip
+- prompt injection risk を diagnostics に出す
+- override なしでは危険 file を content search しない
+
+### permissive-local
+
+local user が明示的に広く検索したい場合の preset。
+
+目的:
+
+- default exclude は薄くする
+- secret-looking file は skip ではなく warning にする
+- user が local で明示的に読む判断をしやすくする
+
+### strict
+
+CI / automation などで誤読を避けたい preset。
+
+目的:
+
+- secret-looking file は hard skip
+- generated / dependency / large file は hard skip
+- unknown or risky file は warning 以上にする
+- override は明示 allowlist のみ許可する
+
+## request JSON 案
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "query": {
+    "type": "literal",
+    "text": "API_KEY"
+  },
+  "search": {
+    "target": "content"
+  },
+  "policy": {
+    "preset": "safe-agent-default",
+    "secretLikeFiles": "skip",
+    "generatedFiles": "warning",
+    "dependencyDirectories": "skip",
+    "lockFiles": "warning",
+    "promptInjectionRisk": "diagnostic",
+    "allowFileNamePatterns": [],
+    "denyFileNamePatterns": [],
+    "allowPathPatterns": [],
+    "denyPathPatterns": [],
+    "explainOverrides": true
+  }
+}
+```
+
+### policy action
+
+各 policy の action 候補:
+
+```text
+ignore
+  policy 判定を行わない
+
+diagnostic
+  検索は続行し、diagnostics に情報として返す
+
+warning
+  検索は続行し、warning diagnostics に返す
+
+skip
+  対象を検索せず、skipped diagnostics に返す
+
+error
+  request または検索を expected failure として止める
+```
+
+MVP では `diagnostic` / `warning` / `skip` だけでもよい。
+
+## policy 種別
+
+### secret-like files
+
+秘密情報を含む可能性が高い file name / path を扱う。
+
+候補 pattern:
+
+```text
+.env
+.env.*
+*.pem
+*.key
+*.p12
+*.pfx
+id_rsa
+id_dsa
+id_ecdsa
+id_ed25519
+credentials*
+*credential*
+*secret*
+*token*
+```
+
+注意:
+
+- file name pattern のみでは false positive / false negative が多い
+- MVP では content secret scanning はしない方がよい
+- content を読まずに skip できることが重要
+
+### generated files
+
+人間や agent が直接読む価値が低い生成物を扱う。
+
+候補 pattern:
+
+```text
+*.generated.*
+*.min.js
+*.bundle.js
+dist/
+build/
+target/
+coverage/
+```
+
+generated docs は製品によって扱いが異なる。例えば API docs や generated Markdown は useful な場合もあるため、default では `warning` が自然である。
+
+### dependency directories
+
+外部依存や vendored source を扱う。
+
+候補:
+
+```text
+node_modules
+vendor
+.gradle
+.m2
+```
+
+`vendor` は repository によっては product source として重要な場合がある。default skip にする場合も、override guidance が必要である。
+
+### lock files
+
+lock file を扱う。
+
+候補:
+
+```text
+package-lock.json
+pnpm-lock.yaml
+yarn.lock
+Cargo.lock
+Gemfile.lock
+poetry.lock
+```
+
+lock file は依存調査では重要だが、通常の source reading ではノイズになりやすい。default は `warning` または `diagnostic` が自然である。
+
+### prompt injection risk
+
+agent に渡すときに、file content を命令として扱ってはいけないことを diagnostics で明示する。
+
+候補:
+
+- Markdown / text / HTML など natural language を含む file
+- `prompt`, `instruction`, `system`, `agent`, `jailbreak` などを file name に含む file
+- external content を取り込んだ docs
+
+重要:
+
+- prompt injection risk は file を危険物として断定するものではない
+- agent が検索結果本文を observation として扱うための warning である
+- MVP では content 解析ではなく path / extension / file name による weak signal にとどめる
+
+## diagnostics 案
+
+policy による判断は diagnostics に構造化して返す。
+
+```json
+{
+  "severity": "warning",
+  "code": "policy_secret_like_file",
+  "message": "file looks like it may contain secrets and was skipped by policy",
+  "file": ".env",
+  "skipped": true,
+  "details": {
+    "policy": "secretLikeFiles",
+    "action": "skip",
+    "matchedPattern": ".env",
+    "override": {
+      "field": "policy.allowFileNamePatterns",
+      "example": [".env"]
+    }
+  }
+}
+```
+
+diagnostic code 候補:
+
+```text
+policy_secret_like_file
+policy_credential_like_file
+policy_generated_file
+policy_dependency_directory
+policy_lock_file
+policy_prompt_injection_risk
+policy_denied_path
+policy_allowed_override
+policy_override_required
+invalid_policy
+invalid_policy_action
+invalid_policy_preset
+```
+
+## override guidance
+
+policy-aware search では、単に skip するだけでなく、明示的に読むための方法を diagnostics に返すと agent / automation が扱いやすい。
+
+例:
+
+```json
+{
+  "details": {
+    "override": {
+      "reason": "To search this file, explicitly allow the file name pattern.",
+      "field": "policy.allowFileNamePatterns",
+      "example": ["*.pem"]
+    }
+  }
+}
+```
+
+ただし secret-like file については、override guidance を出しすぎると危険な自動読み取りを促す可能性がある。`safe-agent-default` では guidance を簡潔にし、user の明示指示を必要とするのがよい。
+
+## result summary 案
+
+summary に policy 関連 count を追加する案。
+
+```json
+{
+  "summary": {
+    "filesVisited": 120,
+    "filesScanned": 80,
+    "filesMatched": 4,
+    "matches": 10,
+    "diagnostics": 6,
+    "policy": {
+      "preset": "safe-agent-default",
+      "filesSkippedByPolicy": 3,
+      "filesWarnedByPolicy": 2,
+      "directoriesSkippedByPolicy": 1
+    },
+    "truncated": false,
+    "truncatedReason": null
+  }
+}
+```
+
+既存 `summary` との互換性を考えると、`summary.policy` のような nested field が自然である。
+
+## MVP 案
+
+MVP で扱うもの:
+
+- `policy.preset`
+- `safe-agent-default`
+- secret-like file name skip
+- dependency / build directory skip
+- generated file warning
+- lock file warning
+- prompt-injection-risk diagnostic
+- policy diagnostics
+
+MVP で扱わないもの:
+
+- content-based secret scanning
+- LLM-based risk classification
+- complex rule language
+- organization policy file
+- remote policy fetch
+- per-language generated file detection
+
+## 実装上の注意
+
+- policy 判定は file read 前にできるものを優先する
+- content を読む必要がある policy は MVP では避ける
+- default exclude preset と policy preset の責務を混ぜすぎない
+- policy による skip と include / exclude による skip の diagnostic code を分ける
+- user が `excludeFileNamePatterns: []` を指定した場合と policy skip の関係を明確にする
+- secret-like file は `output.mode` に関わらず content read 前に止める
+- policy diagnostics は stable order で返す
+- false positive を前提に override 可能にする
+
+## 未決事項
+
+- `miku-grep` 本体に入れるか、別 wrapper / policy layer にするか
+- `policy` field を request schema v1 に追加するか、schema v2 とするか
+- default preset に policy を含めるか、明示 opt-in にするか
+- secret-like file の default action を `warning` にするか `skip` にするか
+- generated docs を generated file として扱うか
+- prompt injection risk をどの程度検出するか
+- diagnostics の override guidance をどこまで具体的にするか
+
+## 判断メモ
+
+利用者向け README に `policy-aware search の強化` とだけ書くと意味が曖昧である。
+
+正式仕様化するまでは、README の後続候補に残すより、この文書や `TODO.md` で「要求整理中」として扱う方がよい。
+
+`miku-grep` の grep 代替としての単純さを守るなら、policy-aware search は opt-in preset として追加するのが自然である。一方、Agent Skills から呼ぶ通常経路では `safe-agent-default` を使う、という分担も考えられる。

--- a/docs/product-candidate-repository-map.md
+++ b/docs/product-candidate-repository-map.md
@@ -1,0 +1,403 @@
+# Repository Map Product Candidate
+
+## 目的
+
+この文書は、repository / directory の構造を生成AI agent や automation が把握しやすい structured map として出力する別プロダクト候補を整理する。
+
+この候補は `miku-grep` の検索機能そのものではない。`miku-grep` が query に対する match を返す tool であるのに対し、repository map tool は query なしで repository の入口、構造、主要 file 候補、除外理由、summary を返す。
+
+## 仮称
+
+候補名:
+
+- `miku-repomap`
+- `miku-repo-map`
+- `miku-indexgen` 系の派生または後継
+
+この文書では仮に `repository map tool` と呼ぶ。
+
+## 背景
+
+生成AI agent が repository を扱うとき、最初に必要なのは全文検索ではなく、どこに何があるかを把握するための軽量な repository overview である。
+
+通常の `tree`、`find`、`ls` は人間向けの表示には便利だが、agent や script が次の判断に使うには次の点が不足する。
+
+- machine-readable な summary がない
+- default exclude や skip reason が構造化されない
+- file 数、directory 数、拡張子分布、entrypoint 候補がまとまらない
+- 生成物、依存 directory、巨大 file、binary file をどう扱ったかが見えにくい
+- 後続の検索や読解で使う候補 file を選びにくい
+
+repository map tool は、local repository を読む前の初期把握を支援する。
+
+## 対象
+
+対象は local repository / directory の構造 inventory である。
+
+扱うもの:
+
+- directory tree summary
+- file inventory
+- extension / directory summary
+- entrypoint file candidates
+- docs / config / build file candidates
+- include / exclude 適用後の visible file set
+- skipped path diagnostics
+- resource limit diagnostics
+
+扱わないもの:
+
+- semantic search
+- embedding search
+- content ranking by meaning
+- source code dependency graph の完全解析
+- language server 相当の symbol index
+- Git repository root の自動推論を前提にした探索
+- project build の実行
+- package install
+
+## `miku-grep` との境界
+
+`miku-grep`:
+
+- query を受け取る
+- content / filename / both を検索する
+- match、summary、diagnostics を返す
+- grep 代替の structured search CLI
+
+repository map tool:
+
+- query を必須にしない
+- repository / directory の構造を要約する
+- 次に読む file 候補を構造情報から提示する
+- 検索 hit ではなく map / inventory / summary を返す
+
+連携例:
+
+1. repository map tool で repository overview を取得する
+2. entrypoint candidates や docs candidates を agent が読む
+3. `miku-grep` で特定語や API 名を検索する
+4. 必要なら repository map tool の include / exclude policy を調整して再取得する
+
+## CLI の基本形
+
+stdin で request JSON を受け取り、stdout に result JSON を返す。
+
+```bash
+miku-repomap < request.json > result.json
+```
+
+`--version` と `--help` は stdin JSON なしで実行できる。
+
+```bash
+miku-repomap --version
+miku-repomap --help
+```
+
+stdout は result JSON 専用とし、progress log や runtime-level message は stderr に出す。
+
+## request JSON 案
+
+```json
+{
+  "version": 1,
+  "root": ".",
+  "map": {
+    "maxDepth": 6,
+    "includeFiles": true,
+    "includeDirectories": true,
+    "includeSummaries": true,
+    "includeEntrypointCandidates": true
+  },
+  "search": {
+    "includeFileNamePatterns": [],
+    "excludeFileNamePatterns": null,
+    "excludeDirNamePatterns": null,
+    "maxFilesVisited": 100000,
+    "maxDirectoriesVisited": 10000
+  },
+  "output": {
+    "mode": "summary",
+    "maxTreeEntries": 1000,
+    "maxFileEntries": 2000
+  }
+}
+```
+
+### root
+
+`root` は map 作成の entry point である。
+
+`root` が相対 path の場合、CLI process の current working directory から解決する。
+
+result JSON 内の file / directory path は `root` からの相対 path とし、絶対 path は返さない。
+
+path separator は platform に関わらず `/` とする。
+
+### map
+
+`map.maxDepth` は tree / traversal の深さを制限する。
+
+`includeFiles` は file entry を result に含めるかを指定する。
+
+`includeDirectories` は directory entry を result に含めるかを指定する。
+
+`includeSummaries` は extension summary、directory summary、size summary などを含めるかを指定する。
+
+`includeEntrypointCandidates` は agent が最初に読む候補 file を抽出するかを指定する。
+
+### search
+
+`search` は traversal 対象を絞るための include / exclude と resource limit を持つ。
+
+`miku-grep` と同様に、default exclude preset を持つのが自然である。
+
+default exclude dir names の候補:
+
+```text
+.git
+.svn
+node_modules
+target
+build
+dist
+.gradle
+.idea
+.vscode
+.settings
+vendor
+```
+
+default exclude file name patterns の候補:
+
+```text
+*.class
+*.jar
+*.zip
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.pdf
+.classpath
+.project
+```
+
+### output
+
+`output.mode` の候補:
+
+```text
+summary
+  agent が最初に読むための compact overview
+
+tree
+  directory tree を中心に返す
+
+inventory
+  file inventory を中心に返す
+
+detail
+  tree、inventory、summary、diagnostics を広く返す
+```
+
+MVP の default は `summary` が自然である。
+
+## result JSON 案
+
+```json
+{
+  "version": 1,
+  "ok": true,
+  "error": null,
+  "effectiveRequest": {},
+  "root": {
+    "path": ".",
+    "name": "example-repo"
+  },
+  "summary": {
+    "directoriesVisited": 12,
+    "filesVisited": 80,
+    "filesIncluded": 64,
+    "filesSkipped": 16,
+    "extensions": [
+      {
+        "extension": ".ts",
+        "files": 24
+      },
+      {
+        "extension": ".md",
+        "files": 6
+      }
+    ],
+    "topDirectories": [
+      {
+        "directory": "src",
+        "files": 30
+      },
+      {
+        "directory": "docs",
+        "files": 8
+      }
+    ],
+    "diagnostics": 0,
+    "truncated": false,
+    "truncatedReason": null
+  },
+  "entrypointCandidates": [
+    {
+      "type": "readme",
+      "file": "README.md",
+      "reason": "repository readme"
+    },
+    {
+      "type": "package",
+      "file": "package.json",
+      "reason": "node package metadata"
+    },
+    {
+      "type": "spec",
+      "file": "docs/miku-grep-cli-spec.md",
+      "reason": "specification document"
+    }
+  ],
+  "tree": [
+    {
+      "type": "directory",
+      "path": "src",
+      "depth": 1
+    },
+    {
+      "type": "file",
+      "path": "src/main.ts",
+      "depth": 2,
+      "extension": ".ts"
+    }
+  ],
+  "files": [
+    {
+      "path": "README.md",
+      "extension": ".md",
+      "sizeBytes": 12000
+    }
+  ],
+  "diagnostics": []
+}
+```
+
+## entrypoint candidates
+
+entrypoint candidates は、agent が最初に読む候補 file の一覧である。
+
+候補 type の例:
+
+```text
+readme
+  README.md など
+
+license
+  LICENSE など
+
+package
+  package.json、pom.xml、build.gradle など
+
+config
+  tsconfig.json、vite.config.ts、eslint config など
+
+spec
+  docs/*spec*.md、docs/*design*.md など
+
+test
+  representative test file
+
+source_entry
+  src/main.*、src/index.*、cli entry file など
+```
+
+MVP では content を読まず、file name / path pattern による候補抽出に限定するのがよい。
+
+## diagnostics
+
+diagnostics は skipped path や resource limit を構造化して返す。
+
+例:
+
+```json
+{
+  "severity": "info",
+  "code": "directory_excluded",
+  "message": "directory was excluded by default exclude preset",
+  "path": "node_modules",
+  "skipped": true
+}
+```
+
+主な diagnostic code 候補:
+
+```text
+directory_excluded
+file_excluded
+symlink_skipped
+path_escape_skipped
+directory_not_readable
+file_not_readable
+max_depth_reached
+max_files_visited
+max_directories_visited
+max_tree_entries
+max_file_entries
+root_not_found
+root_not_accessible
+root_too_broad
+```
+
+## security / safety 方針
+
+`miku-grep` と同様に、local-first CLI として次を守る。
+
+- stdout は JSON result 専用にする
+- request JSON の未知 field は validation error にする
+- `root` の realpath を検索境界として扱う
+- root 外へ解決される path は skip して diagnostics に返す
+- symlink は MVP では追跡しない
+- default exclude preset を持つ
+- 広すぎる root は拒否する
+- result JSON に絶対 path を返さない
+
+## MVP
+
+MVP で扱うもの:
+
+- Node CLI
+- stdin JSON input
+- stdout JSON output
+- `--version`
+- `--help`
+- root-relative tree
+- file inventory
+- default exclude preset
+- max depth
+- traversal resource limit
+- entrypoint candidates
+- extension summary
+- top directory summary
+- diagnostics
+
+MVP で扱わないもの:
+
+- file content の読み取り
+- semantic ranking
+- language-specific parser
+- dependency graph
+- Git history
+- Git ignore の完全解釈
+- MCP
+- Java CLI
+
+## 今後の検討
+
+- `miku-grep` と default exclude preset / diagnostics schema を揃える
+- `miku-grep` request の前段として使いやすい result shape にする
+- file content を読まない MVP と、必要最小限の metadata を読む将来版を分ける
+- `summary` mode の compact さを agent token budget に合わせて調整する
+- repository map result から `miku-grep` request を作りやすい field を追加する


### PR DESCRIPTION
## 概要

README.md を、生成AI agent や JSON を扱える利用者向けの入口情報として再構成しました。

あわせて、これまで後続候補として曖昧に残っていた repository map と policy-aware search について、`miku-grep` 本体の機能ではなく別プロダクト候補の卵として docs 配下に要求整理メモを追加しました。

## 変更内容

- README.md を利用者向けの構成に整理
  - 何に使うか
  - すぐ使う方法
  - よく使う request 例
  - result JSON の読み方
  - 注意点
  - 開発コマンド
  - 関連ドキュメント
  - 関連プロジェクト
  - 後続候補

- README.md に関連プロジェクトを追加
  - Agent Skills 版: `miku-grep-skills`
  - Java 版: `miku-grep-java`

- MCP adapter について、当面対応しない方針を README.md に明記

- 別プロダクト候補メモを追加
  - `docs/product-candidate-repository-map.md`
  - `docs/product-candidate-policy-aware-search.md`

## 補足

`docs/product-candidate-repository-map.md` では、repository / directory の構造を structured map として返す別プロダクト候補について、目的、`miku-grep` との境界、CLI 案、request / result JSON 案、MVP 範囲を整理しています。

`docs/product-candidate-policy-aware-search.md` では、secret-like file、generated file、lock file、prompt injection risk、policy preset、diagnostics、override guidance などを扱う policy-aware search の要求を整理しています。

## 確認

未確認。