### PR TITLE
リファクタリング: 検索処理を責務別に分割し、バージョンを 0.8.4 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-grep",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-grep",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "Apache-2.0",
       "dependencies": {
         "iconv-lite": "^0.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-grep",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Local-first structured grep CLI for AI agents and automation.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/context-lines.ts
+++ b/src/context-lines.ts
@@ -1,0 +1,46 @@
+import type { ContextLine } from "./public-types.js";
+
+export type ContextOptions = {
+  contextLinesBefore: number;
+  contextLinesAfter: number;
+  maxLineChars: number;
+  maxLineLength: number;
+};
+
+export function makeContext(
+  lines: string[],
+  matchIndex: number,
+  options: ContextOptions,
+  onLineSkipped: (line: number, lineChars: number) => void,
+): { contextBefore?: ContextLine[]; contextAfter?: ContextLine[] } {
+  const { contextLinesBefore, contextLinesAfter } = options;
+  if (contextLinesBefore === 0 && contextLinesAfter === 0) return {};
+  return {
+    contextBefore: collectContextLines(lines, Math.max(0, matchIndex - contextLinesBefore), matchIndex, options, onLineSkipped),
+    contextAfter: collectContextLines(lines, matchIndex + 1, Math.min(lines.length, matchIndex + 1 + contextLinesAfter), options, onLineSkipped),
+  };
+}
+
+function collectContextLines(
+  lines: string[],
+  start: number,
+  end: number,
+  options: ContextOptions,
+  onLineSkipped: (line: number, lineChars: number) => void,
+): ContextLine[] {
+  const context: ContextLine[] = [];
+  for (let index = start; index < end; index += 1) {
+    const line = lines[index] ?? "";
+    if (line.length > options.maxLineChars) {
+      onLineSkipped(index + 1, line.length);
+      continue;
+    }
+    context.push(makeContextLine(line, index + 1, options.maxLineLength));
+  }
+  return context;
+}
+
+function makeContextLine(line: string, lineNumber: number, maxLineLength: number): ContextLine {
+  if (line.length <= maxLineLength) return { line: lineNumber, text: line, trimmed: false };
+  return { line: lineNumber, text: line.slice(0, maxLineLength), trimmed: true, textStartColumn: 1 };
+}

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,0 +1,26 @@
+import iconv from "iconv-lite";
+import { globMatch, pathGlobMatch } from "./glob.js";
+import type { EffectiveRequest, EncodingRuleResult, SupportedEncoding } from "./public-types.js";
+
+export function selectEncoding(
+  config: EffectiveRequest["encoding"],
+  relativePath: string,
+  basename: string,
+): { encoding: SupportedEncoding; encodingRule: EncodingRuleResult } {
+  for (const rule of config.rules) {
+    if (rule.pathPattern && pathGlobMatch(relativePath, rule.pathPattern)) {
+      return { encoding: rule.encoding, encodingRule: { type: "pathPattern", pattern: rule.pathPattern } };
+    }
+  }
+  for (const rule of config.rules) {
+    if (rule.fileNamePattern && globMatch(basename, rule.fileNamePattern)) {
+      return { encoding: rule.encoding, encodingRule: { type: "fileNamePattern", pattern: rule.fileNamePattern } };
+    }
+  }
+  return { encoding: config.default, encodingRule: { type: "default" } };
+}
+
+export function decode(bytes: Uint8Array, encoding: SupportedEncoding): string {
+  if (encoding === "utf-8") return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  return iconv.decode(Buffer.from(bytes), "shift_jis");
+}

--- a/src/match-text.ts
+++ b/src/match-text.ts
@@ -1,0 +1,46 @@
+import type { QueryType } from "./public-types.js";
+
+export type TextMatch = {
+  index: number;
+  text: string;
+};
+
+export type Snippet = {
+  text: string;
+  trimmed: boolean;
+  textStartColumn?: number;
+};
+
+export function findMatches(text: string, query: { type: QueryType; text: string }): TextMatch[] {
+  if (query.type === "literal") {
+    const hits: TextMatch[] = [];
+    let from = 0;
+    while (from <= text.length) {
+      const index = text.indexOf(query.text, from);
+      if (index === -1) break;
+      hits.push({ index, text: query.text });
+      from = index + Math.max(query.text.length, 1);
+    }
+    return hits;
+  }
+  const regex = new RegExp(query.text, "g");
+  const hits: TextMatch[] = [];
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    hits.push({ index: match.index, text: match[0] });
+    if (match[0].length === 0) regex.lastIndex += 1;
+  }
+  return hits;
+}
+
+export function makeSnippet(line: string, matchIndex: number, matchLength: number, maxLineLength: number): Snippet {
+  if (line.length <= maxLineLength) return { text: line, trimmed: false };
+  const matchEnd = matchIndex + matchLength;
+  let start = Math.max(0, Math.floor((matchIndex + matchEnd - maxLineLength) / 2));
+  if (start + maxLineLength > line.length) start = Math.max(0, line.length - maxLineLength);
+  return { text: line.slice(start, start + maxLineLength), trimmed: true, ...(start > 0 ? { textStartColumn: start + 1 } : {}) };
+}
+
+export function splitLines(text: string): string[] {
+  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+}

--- a/src/search-results.ts
+++ b/src/search-results.ts
@@ -1,0 +1,100 @@
+import { compareStrings } from "./string-order.js";
+import type { SearchState } from "./internal-types.js";
+import type { DetailMatch, DirectorySummaryMatch, FileSummaryMatch } from "./public-types.js";
+
+export function addFileHit(state: SearchState, file: string, hit: DetailMatch): void {
+  if (state.summary.matches >= state.request.output.maxMatches) {
+    markTruncated(state, "max_matches", "search stopped because maxMatches was reached", { maxMatches: state.request.output.maxMatches });
+    state.globalLimitReached = true;
+    return;
+  }
+  state.summary.matches += 1;
+  const detail = state.detailsByFile.get(file) ?? [];
+  detail.push(hit);
+  state.detailsByFile.set(file, detail);
+
+  const summary = state.summariesByFile.get(file) ?? {
+    type: "file",
+    file,
+    matchTypes: [],
+    filepathMatched: false,
+    contentMatched: false,
+    lines: [],
+    matchCount: 0,
+    snippets: [],
+  };
+  summary.matchCount += 1;
+  if (hit.type === "filepath") {
+    summary.filepathMatched = true;
+    if (!summary.matchTypes.includes("filepath")) summary.matchTypes.push("filepath");
+  } else if (hit.type === "content") {
+    summary.contentMatched = true;
+    if (!summary.matchTypes.includes("content")) summary.matchTypes.push("content");
+    if (!summary.lines.includes(hit.line)) summary.lines.push(hit.line);
+    if (summary.snippets.length < state.request.output.maxSnippetsPerFile) {
+      const snippet: FileSummaryMatch["snippets"][number] = { type: "content", line: hit.line, text: hit.text, trimmed: hit.trimmed };
+      if (hit.textStartColumn) snippet.textStartColumn = hit.textStartColumn;
+      summary.snippets.push(snippet);
+    } else {
+      markTruncated(state, "max_snippets_per_file", "snippets were omitted because maxSnippetsPerFile was reached", { file, maxSnippetsPerFile: state.request.output.maxSnippetsPerFile });
+    }
+    summary.encoding = hit.encoding;
+    summary.encodingRule = hit.encodingRule;
+  }
+  state.summariesByFile.set(file, summary);
+}
+
+export function addDirectoryHit(state: SearchState, directoryPath: string, hit: DetailMatch): void {
+  if (state.summary.matches >= state.request.output.maxMatches) {
+    markTruncated(state, "max_matches", "search stopped because maxMatches was reached", { maxMatches: state.request.output.maxMatches });
+    state.globalLimitReached = true;
+    return;
+  }
+  state.summary.matches += 1;
+  const detail = state.detailsByDirectory.get(directoryPath) ?? [];
+  detail.push(hit);
+  state.detailsByDirectory.set(directoryPath, detail);
+
+  const summary = state.summariesByDirectory.get(directoryPath) ?? {
+    type: "directory",
+    path: directoryPath,
+    matchTypes: ["directory"],
+    directoryMatched: true,
+    matchCount: 0,
+  };
+  summary.matchCount += 1;
+  state.summariesByDirectory.set(directoryPath, summary);
+}
+
+export function markTruncated(state: SearchState, reason: string, message: string, details: Record<string, unknown>): void {
+  if (!state.summary.truncated) {
+    state.summary.truncated = true;
+    state.summary.truncatedReason = reason;
+  }
+  const diagnosticKey = `${reason}:${JSON.stringify(details)}`;
+  if (state.truncationDiagnosticKeys.has(diagnosticKey)) return;
+  state.truncationDiagnosticKeys.add(diagnosticKey);
+  state.diagnostics.push({ severity: "info", code: reason, message, details });
+}
+
+export function buildDetailMatches(state: SearchState): DetailMatch[] {
+  return [...state.detailsByDirectory.entries(), ...state.detailsByFile.entries()]
+    .sort(([a], [b]) => compareStrings(a, b))
+    .flatMap(([, hits]) => hits.sort((a, b) => typeRank(a.type) - typeRank(b.type) || ((a.type === "content" ? a.line : 0) - (b.type === "content" ? b.line : 0)) || ((a.type === "content" ? a.column : 0) - (b.type === "content" ? b.column : 0))));
+}
+
+export function buildSummaryMatches(state: SearchState): Array<FileSummaryMatch | DirectorySummaryMatch> {
+  return [...state.summariesByDirectory.values(), ...state.summariesByFile.values()]
+    .sort((a, b) => compareStrings(summaryPath(a), summaryPath(b)))
+    .map((item) => (item.type === "file" ? { ...item, lines: item.lines.sort((a, b) => a - b) } : item));
+}
+
+function typeRank(type: DetailMatch["type"]): number {
+  if (type === "directory") return 0;
+  if (type === "filepath") return 1;
+  return 2;
+}
+
+function summaryPath(item: FileSummaryMatch | DirectorySummaryMatch): string {
+  return item.type === "file" ? item.file : item.path;
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,23 +1,19 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import iconv from "iconv-lite";
-import { globMatch, matchesAny, pathGlobMatch } from "./glob.js";
+import { makeContext } from "./context-lines.js";
+import { decode, selectEncoding } from "./encoding.js";
+import { matchesAny } from "./glob.js";
 import { isIgnoredByRules, loadIgnoreRulesForDirectory } from "./ignore-files.js";
+import { findMatches, makeSnippet, splitLines } from "./match-text.js";
 import { isPathInsideOrSame } from "./path-security.js";
 import { createSummary } from "./result.js";
+import { addDirectoryHit, addFileHit, buildDetailMatches, buildSummaryMatches, markTruncated } from "./search-results.js";
 import { compareStrings } from "./string-order.js";
 import type { SearchResult, SearchState } from "./internal-types.js";
 import type { IgnoreRule } from "./ignore-files.js";
 import type {
-  ContextLine,
-  DetailMatch,
   Diagnostic,
-  DirectorySummaryMatch,
   EffectiveRequest,
-  EncodingRuleResult,
-  FileSummaryMatch,
-  QueryType,
-  SupportedEncoding,
 } from "./public-types.js";
 
 export async function runSearch(request: EffectiveRequest, rootPath: string, diagnostics: Diagnostic[]): Promise<SearchResult> {
@@ -181,7 +177,17 @@ async function searchFile(state: SearchState, absolutePath: string, relativePath
         return;
       }
       const snippet = makeSnippet(line, match.index, match.text.length, state.request.output.maxLineLength);
-      const context = makeContext(state, lines, index, relativePath);
+      const context = makeContext(
+        lines,
+        index,
+        {
+          contextLinesBefore: state.request.output.contextLinesBefore,
+          contextLinesAfter: state.request.output.contextLinesAfter,
+          maxLineChars: state.request.search.maxLineChars,
+          maxLineLength: state.request.output.maxLineLength,
+        },
+        (line, lineChars) => markLineSkipped(state, relativePath, line, lineChars),
+      );
       addFileHit(state, relativePath, {
         type: "content",
         file: relativePath,
@@ -232,183 +238,6 @@ async function resolveInsideRoot(state: SearchState, absolutePath: string, relat
   return realPath;
 }
 
-function addFileHit(state: SearchState, file: string, hit: DetailMatch): void {
-  if (state.summary.matches >= state.request.output.maxMatches) {
-    markTruncated(state, "max_matches", "search stopped because maxMatches was reached", { maxMatches: state.request.output.maxMatches });
-    state.globalLimitReached = true;
-    return;
-  }
-  state.summary.matches += 1;
-  const detail = state.detailsByFile.get(file) ?? [];
-  detail.push(hit);
-  state.detailsByFile.set(file, detail);
-
-  const summary = state.summariesByFile.get(file) ?? {
-    type: "file",
-    file,
-    matchTypes: [],
-    filepathMatched: false,
-    contentMatched: false,
-    lines: [],
-    matchCount: 0,
-    snippets: [],
-  };
-  summary.matchCount += 1;
-  if (hit.type === "filepath") {
-    summary.filepathMatched = true;
-    if (!summary.matchTypes.includes("filepath")) summary.matchTypes.push("filepath");
-  } else if (hit.type === "content") {
-    summary.contentMatched = true;
-    if (!summary.matchTypes.includes("content")) summary.matchTypes.push("content");
-    if (!summary.lines.includes(hit.line)) summary.lines.push(hit.line);
-    if (summary.snippets.length < state.request.output.maxSnippetsPerFile) {
-      const snippet: FileSummaryMatch["snippets"][number] = { type: "content", line: hit.line, text: hit.text, trimmed: hit.trimmed };
-      if (hit.textStartColumn) snippet.textStartColumn = hit.textStartColumn;
-      summary.snippets.push(snippet);
-    } else {
-      markTruncated(state, "max_snippets_per_file", "snippets were omitted because maxSnippetsPerFile was reached", { file, maxSnippetsPerFile: state.request.output.maxSnippetsPerFile });
-    }
-    summary.encoding = hit.encoding;
-    summary.encodingRule = hit.encodingRule;
-  }
-  state.summariesByFile.set(file, summary);
-}
-
-function addDirectoryHit(state: SearchState, directoryPath: string, hit: DetailMatch): void {
-  if (state.summary.matches >= state.request.output.maxMatches) {
-    markTruncated(state, "max_matches", "search stopped because maxMatches was reached", { maxMatches: state.request.output.maxMatches });
-    state.globalLimitReached = true;
-    return;
-  }
-  state.summary.matches += 1;
-  const detail = state.detailsByDirectory.get(directoryPath) ?? [];
-  detail.push(hit);
-  state.detailsByDirectory.set(directoryPath, detail);
-
-  const summary = state.summariesByDirectory.get(directoryPath) ?? {
-    type: "directory",
-    path: directoryPath,
-    matchTypes: ["directory"],
-    directoryMatched: true,
-    matchCount: 0,
-  };
-  summary.matchCount += 1;
-  state.summariesByDirectory.set(directoryPath, summary);
-}
-
-function markTruncated(state: SearchState, reason: string, message: string, details: Record<string, unknown>): void {
-  if (!state.summary.truncated) {
-    state.summary.truncated = true;
-    state.summary.truncatedReason = reason;
-  }
-  const diagnosticKey = `${reason}:${JSON.stringify(details)}`;
-  if (state.truncationDiagnosticKeys.has(diagnosticKey)) return;
-  state.truncationDiagnosticKeys.add(diagnosticKey);
-  state.diagnostics.push({ severity: "info", code: reason, message, details });
-}
-
-function buildDetailMatches(state: SearchState): DetailMatch[] {
-  return [...state.detailsByDirectory.entries(), ...state.detailsByFile.entries()]
-    .sort(([a], [b]) => compareStrings(a, b))
-    .flatMap(([, hits]) => hits.sort((a, b) => typeRank(a.type) - typeRank(b.type) || ((a.type === "content" ? a.line : 0) - (b.type === "content" ? b.line : 0)) || ((a.type === "content" ? a.column : 0) - (b.type === "content" ? b.column : 0))));
-}
-
-function buildSummaryMatches(state: SearchState): Array<FileSummaryMatch | DirectorySummaryMatch> {
-  return [...state.summariesByDirectory.values(), ...state.summariesByFile.values()]
-    .sort((a, b) => compareStrings(summaryPath(a), summaryPath(b)))
-    .map((item) => (item.type === "file" ? { ...item, lines: item.lines.sort((a, b) => a - b) } : item));
-}
-
-function typeRank(type: DetailMatch["type"]): number {
-  if (type === "directory") return 0;
-  if (type === "filepath") return 1;
-  return 2;
-}
-
 function hasTarget(state: SearchState, target: EffectiveRequest["search"]["targets"][number]): boolean {
   return state.request.search.targets.includes(target);
-}
-
-function summaryPath(item: FileSummaryMatch | DirectorySummaryMatch): string {
-  return item.type === "file" ? item.file : item.path;
-}
-
-function findMatches(text: string, query: { type: QueryType; text: string }): Array<{ index: number; text: string }> {
-  if (query.type === "literal") {
-    const hits: Array<{ index: number; text: string }> = [];
-    let from = 0;
-    while (from <= text.length) {
-      const index = text.indexOf(query.text, from);
-      if (index === -1) break;
-      hits.push({ index, text: query.text });
-      from = index + Math.max(query.text.length, 1);
-    }
-    return hits;
-  }
-  const regex = new RegExp(query.text, "g");
-  const hits: Array<{ index: number; text: string }> = [];
-  let match;
-  while ((match = regex.exec(text)) !== null) {
-    hits.push({ index: match.index, text: match[0] });
-    if (match[0].length === 0) regex.lastIndex += 1;
-  }
-  return hits;
-}
-
-function makeSnippet(line: string, matchIndex: number, matchLength: number, maxLineLength: number): { text: string; trimmed: boolean; textStartColumn?: number } {
-  if (line.length <= maxLineLength) return { text: line, trimmed: false };
-  const matchEnd = matchIndex + matchLength;
-  let start = Math.max(0, Math.floor((matchIndex + matchEnd - maxLineLength) / 2));
-  if (start + maxLineLength > line.length) start = Math.max(0, line.length - maxLineLength);
-  return { text: line.slice(start, start + maxLineLength), trimmed: true, ...(start > 0 ? { textStartColumn: start + 1 } : {}) };
-}
-
-function makeContext(state: SearchState, lines: string[], matchIndex: number, file: string): { contextBefore?: ContextLine[]; contextAfter?: ContextLine[] } {
-  const { contextLinesBefore, contextLinesAfter } = state.request.output;
-  if (contextLinesBefore === 0 && contextLinesAfter === 0) return {};
-  return {
-    contextBefore: collectContextLines(state, lines, Math.max(0, matchIndex - contextLinesBefore), matchIndex, file),
-    contextAfter: collectContextLines(state, lines, matchIndex + 1, Math.min(lines.length, matchIndex + 1 + contextLinesAfter), file),
-  };
-}
-
-function collectContextLines(state: SearchState, lines: string[], start: number, end: number, file: string): ContextLine[] {
-  const context: ContextLine[] = [];
-  for (let index = start; index < end; index += 1) {
-    const line = lines[index] ?? "";
-    if (line.length > state.request.search.maxLineChars) {
-      markLineSkipped(state, file, index + 1, line.length);
-      continue;
-    }
-    context.push(makeContextLine(line, index + 1, state.request.output.maxLineLength));
-  }
-  return context;
-}
-
-function makeContextLine(line: string, lineNumber: number, maxLineLength: number): ContextLine {
-  if (line.length <= maxLineLength) return { line: lineNumber, text: line, trimmed: false };
-  return { line: lineNumber, text: line.slice(0, maxLineLength), trimmed: true, textStartColumn: 1 };
-}
-
-function splitLines(text: string): string[] {
-  return text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
-}
-
-function selectEncoding(config: EffectiveRequest["encoding"], relativePath: string, basename: string): { encoding: SupportedEncoding; encodingRule: EncodingRuleResult } {
-  for (const rule of config.rules) {
-    if (rule.pathPattern && pathGlobMatch(relativePath, rule.pathPattern)) {
-      return { encoding: rule.encoding, encodingRule: { type: "pathPattern", pattern: rule.pathPattern } };
-    }
-  }
-  for (const rule of config.rules) {
-    if (rule.fileNamePattern && globMatch(basename, rule.fileNamePattern)) {
-      return { encoding: rule.encoding, encodingRule: { type: "fileNamePattern", pattern: rule.fileNamePattern } };
-    }
-  }
-  return { encoding: config.default, encodingRule: { type: "default" } };
-}
-
-function decode(bytes: Uint8Array, encoding: SupportedEncoding): string {
-  if (encoding === "utf-8") return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
-  return iconv.decode(Buffer.from(bytes), "shift_jis");
 }


### PR DESCRIPTION
## 概要

`search.ts` に集約されていた検索関連処理を、責務ごとのモジュールへ分割しました。

あわせて、パッケージバージョンを `0.8.3` から `0.8.4` に更新しました。

## 変更内容

- context lines 生成処理を `context-lines.ts` に分離
- エンコーディング選択と decode 処理を `encoding.ts` に分離
- テキストマッチ、スニペット生成、行分割処理を `match-text.ts` に分離
- 検索結果の集約、summary/detail matches 構築、truncation diagnostics 処理を `search-results.ts` に分離
- `search.ts` 側は traversal と file scan の制御を中心に整理
- `package.json` と `package-lock.json` のバージョンを `0.8.4` に更新

## 確認

- `npm test`
- `npm run build`