### PR TITLE
filepath / directory detail mode の path hit を代表 1 件に集約する

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ include / exclude は glob pattern です。`query.type: "regex"` は検索語�
 
 `.gitignore`、`.ignore`、`.git/info/exclude` は既定で尊重されます。ignore file を無効にして検索したい場合は `ignore.mode: "none"` を指定します。
 
+注意: ignore file 対応は Git ignore の subset です。現時点では `!pattern` による negation / unignore など一部の pattern は未対応で、該当 pattern は `unsupported_ignore_pattern` warning diagnostic として報告されます。
+
 ```json
 {
   "version": 1,
@@ -321,7 +323,7 @@ stdout の result JSON は、成功時も期待可能な失敗時も同じ top-l
 
 `summary` mode の `matches[]` は、matched file / matched directory を item として返します。agent が次に読む file や見るべき directory を選ぶ最初の検索に向いています。
 
-`detail` mode の `matches[]` は、1 hit = 1 item です。line、column、matched text、snippet を見たい場合に使います。
+`detail` mode の `matches[]` は、content target では 1 content hit = 1 item です。filepath / directory target では 1 matched path = 最大 1 item で、同じ path 文字列内に複数 match がある場合は代表 `matchedText` を返します。line、column、matched text、snippet を見たい場合に使います。
 
 ## 注意点
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,26 @@
 
 ## next specification candidates
 
+- [x] filepath / directory detail mode の同一 path 複数 hit を代表 hit に集約する
+  - 優先度: 高め。`query.type: "regex", text: ".*"` で path 一覧を取ると、末尾 zero-length match により同じ path が複数 item になりやすい。
+  - 目的: `filepath` / `directory` target の `detail` mode では、同一 file path / directory path を最大 1 item として返す。
+  - 実装: `content` target の `detail` mode は従来どおり 1 content hit = 1 item を維持。
+  - 実装: path target の代表 `matchedText` は、最初の non-empty match を優先し、なければ最初の zero-length match を使う。
+  - 実装: path target の `summary.matches` / summary item `matchCount` も代表 hit 1 件として数える。
+  - 実装: `detail returns one item per hit` という README / CLI spec の説明を、content hit と path hit の違いが分かる表現へ更新。
+  - 実装: `findMatches()` は content 用の全 hit 列挙として維持し、path target 側だけ representative hit を選ぶ helper を追加。
+  - 確認: `npm test` が成功。
+  - 関連: `docs/miku-grep-cli-spec.md`, `docs/miku-grep-search-targets-spec.md`
+
+- [ ] ignore file の negation / unignore pattern 対応を仕様検討・実装する
+  - 優先度: 高め。`.gitignore` を尊重すると説明する以上、`!pattern` は利用者の期待に入りやすい。
+  - 目的: `!keep.tmp` のような negation / unignore pattern を warning ではなく有効な ignore rule として扱う。
+  - 現状: `!pattern` は `unsupported_ignore_pattern` warning diagnostic として報告し、該当 pattern だけ skip している。
+  - 検討: ignore rule を単純な OR 除外ではなく、source / directory / 行順を維持した順序評価にする。
+  - 検討: 既存 subset の glob に対する negation だけを MVP 対象にし、Git ignore 完全互換とは分けて説明する。
+  - 検討: ignored directory 配下の file を unignore する場合の扱いを仕様化する。
+  - 関連: `docs/miku-grep-ignore-files-spec.md`
+
 - [x] ディレクトリ検索機能を仕様検討・実装する
   - 目的: `find` 代替として、file だけでなく directory entry も検索・返せるようにする。
   - 実装: `search.targets` 配列で `filepath` / `directory` / `content` を組み合わせられるようにした。

--- a/docs/miku-grep-cli-spec.md
+++ b/docs/miku-grep-cli-spec.md
@@ -796,7 +796,16 @@ When `maxMatchesPerFile` is reached, search for that file stops, but traversal c
 
 ### detail
 
-`detail` returns one item per hit.
+`detail` returns one item per content hit for `content` targets.
+
+For `filepath` and `directory` targets, `detail` returns at most one item per matched path. If the query has multiple matches in the same path string, the returned item uses a representative `matchedText`.
+
+Representative path `matchedText` selection:
+
+```text
+1. first non-empty match
+2. first zero-length match when there is no non-empty match
+```
 
 Content hit:
 
@@ -1123,6 +1132,7 @@ directoriesIgnored
 
 matches
   Total hit count.
+  For filepath and directory targets, multiple query matches in the same path count as one representative hit.
   In detail mode this usually equals matches[] length.
   In summary mode this may differ from matches[] length.
 

--- a/docs/miku-grep-search-targets-spec.md
+++ b/docs/miku-grep-search-targets-spec.md
@@ -171,6 +171,19 @@ detail
 
 ## detail mode result
 
+`content` target の `detail` mode は 1 content hit = 1 item を返す。
+
+`filepath` / `directory` target の `detail` mode は 1 matched path = 最大 1 item を返す。同じ path 文字列内で query が複数回 match する場合、代表 match を 1 件だけ返す。
+
+代表 `matchedText` は次の優先順位で選ぶ。
+
+```text
+1. 最初の non-empty match
+2. non-empty match がなければ最初の zero-length match
+```
+
+このため、regex `.*` で path 一覧を取得しても、末尾の zero-length match によって同じ file / directory が複数 item になることはない。
+
 ### filepath match
 
 ```json

--- a/src/match-text.ts
+++ b/src/match-text.ts
@@ -33,6 +33,10 @@ export function findMatches(text: string, query: { type: QueryType; text: string
   return hits;
 }
 
+export function chooseRepresentativeMatch(matches: TextMatch[]): TextMatch | null {
+  return matches.find((match) => match.text.length > 0) ?? matches[0] ?? null;
+}
+
 export function makeSnippet(line: string, matchIndex: number, matchLength: number, maxLineLength: number): Snippet {
   if (line.length <= maxLineLength) return { text: line, trimmed: false };
   const matchEnd = matchIndex + matchLength;

--- a/src/search.ts
+++ b/src/search.ts
@@ -4,7 +4,7 @@ import { makeContext } from "./context-lines.js";
 import { decode, selectEncoding } from "./encoding.js";
 import { matchesAny } from "./glob.js";
 import { isIgnoredByRules, loadIgnoreRulesForDirectory } from "./ignore-files.js";
-import { findMatches, makeSnippet, splitLines } from "./match-text.js";
+import { chooseRepresentativeMatch, findMatches, makeSnippet, splitLines } from "./match-text.js";
 import { isPathInsideOrSame } from "./path-security.js";
 import { createSummary } from "./result.js";
 import { addDirectoryHit, addFileHit, buildDetailMatches, buildSummaryMatches, markTruncated } from "./search-results.js";
@@ -78,7 +78,8 @@ async function traverse(state: SearchState, absoluteDir: string, relativeDir: st
       state.summary.directoriesVisited += 1;
       if (hasTarget(state, "directory")) {
         state.summary.directoriesScanned += 1;
-        for (const hit of findMatches(relativePath, state.request.query)) {
+        const hit = chooseRepresentativeMatch(findMatches(relativePath, state.request.query));
+        if (hit) {
           addDirectoryHit(state, relativePath, { type: "directory", path: relativePath, matchedText: hit.text });
         }
       }
@@ -115,7 +116,8 @@ async function searchFile(state: SearchState, absolutePath: string, relativePath
   if (searchFilepath) {
     countedScanned = true;
     state.summary.filesScanned += 1;
-    for (const hit of findMatches(relativePath, state.request.query)) {
+    const hit = chooseRepresentativeMatch(findMatches(relativePath, state.request.query));
+    if (hit) {
       addFileHit(state, relativePath, { type: "filepath", file: relativePath, matchedText: hit.text });
     }
   }

--- a/test/search-filename.test.ts
+++ b/test/search-filename.test.ts
@@ -192,6 +192,58 @@ describe("miku-grep filepath, directory, and combined search", () => {
     ]);
   });
 
+  test("returns at most one detail filepath hit per path", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.writeFile(path.join(root, "README.md"), "readme\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: ".*" },
+      search: { targets: ["filepath"] },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([{ type: "filepath", file: "README.md", matchedText: "README.md" }]);
+    expect(result.summary.matches).toBe(1);
+  });
+
+  test("returns at most one detail directory hit per path", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "docs"), { recursive: true });
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: ".*" },
+      search: { targets: ["directory"] },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([{ type: "directory", path: "docs", matchedText: "docs" }]);
+    expect(result.summary.matches).toBe(1);
+  });
+
+  test("keeps zero-length representative path hits when no non-empty hit exists", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "src"), { recursive: true });
+    await fs.writeFile(path.join(root, "src", "foo.ts"), "no content hit\n", "utf8");
+
+    const result = await runRequest({
+      version: 1,
+      root,
+      query: { type: "regex", text: "(?=foo)" },
+      search: { targets: ["filepath"] },
+      output: { mode: "detail" },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.matches).toEqual([{ type: "filepath", file: "src/foo.ts", matchedText: "" }]);
+    expect(result.summary.matches).toBe(1);
+  });
+
   test("aggregates filepath and content hits in summary mode", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
     await fs.mkdir(path.join(root, "src"), { recursive: true });


### PR DESCRIPTION
## 概要

`filepath` / `directory` target の `detail` mode で、同一 path 文字列内に複数 match がある場合でも、返却する item を最大 1 件に集約するよう変更しました。

これにより、`query.type: "regex", text: ".*"` のような request で path 一覧を取得する際、末尾の zero-length match によって同じ file / directory が複数回 `matches[]` に出る問題を避けます。

## 変更内容

- `filepath` / `directory` target の `detail` mode で、同一 path ごとに代表 hit 1 件だけを返すよう変更
- 代表 `matchedText` の選択ルールを追加
  - 最初の non-empty match を優先
  - non-empty match がない場合は最初の zero-length match を使用
- `content` target の `detail` mode は従来どおり 1 content hit = 1 item を維持
- `summary.matches` / summary item の `matchCount` でも path target は代表 hit 1 件として数える仕様を反映
- README と仕様書の `detail` mode 説明を、content hit と path hit の違いが分かる表現に更新
- `.*` と zero-length only match の挙動を確認するテストを追加
- ignore file の `!pattern` negation / unignore 未対応について README に注意書きを追加し、TODO に対応予定として追記

## 確認

- `npm test` が成功