### PR TITLE
バージョンを0.9.0へ更新する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-grep",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-grep",
-      "version": "0.8.4",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "iconv-lite": "^0.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-grep",
-  "version": "0.8.4",
+  "version": "0.9.0",
   "description": "Local-first structured grep CLI for AI agents and automation.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## 概要

大幅に変わりました。このため、
`miku-grep` の package version を `0.8.4` から `0.9.0` に更新しました。

## 変更内容

- `package.json` の `version` を `0.9.0` に更新
- `package-lock.json` の root package version を `0.9.0` に更新
- `package-lock.json` の packages entry にある `miku-grep` version を `0.9.0` に更新