### PR TITLE
listFiles の出力順と filesScanned 集計を修正する

### DIFF
--- a/docs/miku-grep-cli-spec.md
+++ b/docs/miku-grep-cli-spec.md
@@ -1002,6 +1002,10 @@ When `maxMatchesPerFile` is reached, search for that file stops, but traversal c
 `files[]` is sorted by root-relative path using the same deterministic path
 ordering as search results.
 
+In `listFiles` mode, `summary.filesScanned` counts files that passed ignore and
+include / exclude filtering and were checked for optional inventory filtering.
+It can be larger than `files[]` length when a glob query filters the inventory.
+
 ### detail
 
 `detail` returns one item per content hit for `content` targets.

--- a/src/list-files.ts
+++ b/src/list-files.ts
@@ -32,7 +32,7 @@ export async function runListFiles(request: EffectiveRequest, rootPath: string, 
   };
 
   await traverse(state, rootPath, "", 0, []);
-  state.summary.filesScanned = state.files.length;
+  state.files.sort((a, b) => compareStrings(a.path, b.path));
   state.summary.diagnostics = diagnostics.length;
   return { files: state.files, fileSummary: summarizeFiles(state.files), summary: state.summary };
 }
@@ -90,6 +90,7 @@ async function traverse(state: ListFilesState, absoluteDir: string, relativeDir:
       continue;
     }
     if (!candidateFile(state, entry.name)) continue;
+    state.summary.filesScanned += 1;
     if (state.request.query && findMatches(relativePath, state.request.query).length === 0) continue;
     state.files.push({
       path: relativePath,

--- a/test/list-files.test.ts
+++ b/test/list-files.test.ts
@@ -7,10 +7,13 @@ import { runRequest } from "../src/main.js";
 describe("miku-grep listFiles mode", () => {
   test("lists files with summaries and default excludes", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
+    await fs.mkdir(path.join(root, "a"), { recursive: true });
     await fs.mkdir(path.join(root, "docs"), { recursive: true });
     await fs.mkdir(path.join(root, "src"), { recursive: true });
     await fs.mkdir(path.join(root, "node_modules", "pkg"), { recursive: true });
     await fs.writeFile(path.join(root, "README.md"), "readme\n", "utf8");
+    await fs.writeFile(path.join(root, "a", "b.txt"), "nested\n", "utf8");
+    await fs.writeFile(path.join(root, "a.txt"), "sibling\n", "utf8");
     await fs.writeFile(path.join(root, "docs", "guide.md"), "guide\n", "utf8");
     await fs.writeFile(path.join(root, "src", "main.ts"), "main\n", "utf8");
     await fs.writeFile(path.join(root, "node_modules", "pkg", "index.js"), "skip\n", "utf8");
@@ -27,23 +30,27 @@ describe("miku-grep listFiles mode", () => {
     expect(result.matches).toEqual([]);
     expect(result.files).toEqual([
       { path: "README.md", extension: ".md", directory: "." },
+      { path: "a.txt", extension: ".txt", directory: "." },
+      { path: "a/b.txt", extension: ".txt", directory: "a" },
       { path: "docs/guide.md", extension: ".md", directory: "docs" },
       { path: "src/main.ts", extension: ".ts", directory: "src" },
     ]);
     expect(result.fileSummary).toEqual({
-      files: 3,
+      files: 5,
       extensions: [
         { extension: ".md", count: 2 },
+        { extension: ".txt", count: 2 },
         { extension: ".ts", count: 1 },
       ],
       directories: [
-        { path: ".", count: 1 },
+        { path: ".", count: 2 },
+        { path: "a", count: 1 },
         { path: "docs", count: 1 },
         { path: "src", count: 1 },
       ],
     });
-    expect(result.summary.filesVisited).toBe(3);
-    expect(result.summary.filesScanned).toBe(3);
+    expect(result.summary.filesVisited).toBe(5);
+    expect(result.summary.filesScanned).toBe(5);
   });
 
   test("respects ignore files and include patterns", async () => {
@@ -89,6 +96,8 @@ describe("miku-grep listFiles mode", () => {
     expect(result.ok).toBe(true);
     expect(result.files).toEqual([{ path: "docs/guide.md", extension: ".md", directory: "docs" }]);
     expect(result.fileSummary?.files).toBe(1);
+    expect(result.summary.filesVisited).toBe(3);
+    expect(result.summary.filesScanned).toBe(3);
   });
 
   test("rejects query in listFiles mode", async () => {


### PR DESCRIPTION
## 概要

`listFiles` mode の file inventory 出力について、仕様どおり root-relative path 順で返すようにし、`summary.filesScanned` の集計を inventory filtering の対象 file 数として扱うよう修正します。

## 変更内容

- `listFiles` の `files[]` を traversal 後に root-relative path 順で sort
- `summary.filesScanned` を返却 file 数ではなく、ignore と include / exclude を通過して optional inventory filtering の対象になった file 数として加算
- `listFiles` のテスト fixture を拡張し、`a.txt` と `a/b.txt` の順序を検証
- glob query で `files[]` が絞り込まれる場合でも `filesScanned` が照合対象 file 数になることをテストで確認
- CLI spec に `listFiles` mode における `summary.filesScanned` の意味を追記