### PR TITLE
Node CLI の listFiles help 文言を glob query 対応に合わせる

### DIFF
--- a/src/help.ts
+++ b/src/help.ts
@@ -55,7 +55,7 @@ REQUEST FIELDS
   mode
     "search" or "listFiles". Default: "search".
     "search" requires query.
-    "listFiles" returns file inventory JSON and must not specify query.
+    "listFiles" returns file inventory JSON. Optional query must use query.type "glob".
 
   search.targets
     Non-empty array of "filepath", "directory", and/or "content".

--- a/test/list-files.test.ts
+++ b/test/list-files.test.ts
@@ -100,7 +100,7 @@ describe("miku-grep listFiles mode", () => {
     expect(result.summary.filesScanned).toBe(3);
   });
 
-  test("rejects query in listFiles mode", async () => {
+  test("rejects non-glob query in listFiles mode", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "miku-grep-test-"));
     const result = await runRequest({
       version: 1,


### PR DESCRIPTION
## 概要

Node CLI `--help` の `listFiles` mode 説明を、実際の request validation と仕様に合わせて修正します。

`listFiles` mode では query 自体は禁止ではなく、任意 query を指定する場合は `query.type: "glob"` のみ利用できるため、その内容が伝わる文言に変更します。

## 変更内容

- `src/help.ts` の `listFiles` mode 説明を修正
  - 旧: query を指定してはいけない
  - 新: 任意 query は `query.type "glob"` を使う必要がある
- `test/list-files.test.ts` のテスト名を実挙動に合わせて修正
  - `rejects query in listFiles mode`
  - `rejects non-glob query in listFiles mode`

## 確認

- `npm run test`
- `npm run build`
- `npm run smoke:bundle`