### PR TITLE
args-first CLI と text default 出力を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `miku-grep` は、生成AI agent と automation が repository やディレクトリ内で「読むべきファイル」を見つけるための local-first 検索 CLI です。
 
-通常の `grep` の代わりに、検索結果、summary、diagnostics を JSON として返します。人間が画面で読む検索結果ではなく、次の処理に渡しやすい structured result を得るための tool です。
+短い `grep` 風の引数で検索でき、既定では画面で読みやすい text を返します。機械処理や script 連携が必要な場合は `--format json` または stdin request JSON で、検索結果、summary、diagnostics を structured result として受け取れます。
 
 厳格な CLI / JSON 仕様は [docs/miku-grep-cli-spec.md](docs/miku-grep-cli-spec.md) を参照してください。
 
@@ -27,7 +27,29 @@ AI agent が「探す」「候補を絞る」「次に読む file を選ぶ」�
 
 ## すぐ使う
 
-stdin で request JSON を渡し、stdout から result JSON を受け取ります。
+まずは短い引数で検索できます。既定の出力は text です。
+
+```bash
+miku-grep TODO .
+miku-grep TODO . --context 2
+miku-grep TODO . --files
+miku-grep TODO . --agent
+miku-grep TODO . --encoding shift_jis
+```
+
+JSON が必要な場合は `--format json` を指定します。
+
+```bash
+miku-grep TODO . --format json
+```
+
+file inventory は `--files` だけで取得できます。
+
+```bash
+miku-grep --files .
+```
+
+stdin で request JSON を渡し、stdout から result JSON を受け取る詳細入口も利用できます。
 
 ```bash
 miku-grep < request.json > result.json
@@ -60,7 +82,7 @@ miku-grep --version
 miku-grep --help
 ```
 
-`--help` は、生成AI agent や automation が request JSON を組み立てるために必要な stdin / stdout contract、request field、default、result shape、diagnostics、例を stdout に出力します。
+`--help` は、短い引数の使い方、JSON request の contract、request field、default、result shape、diagnostics、例を stdout に出力します。
 
 ## よく使う request
 

--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,15 @@
 
 ## next specification candidates
 
+- [x] args-first + text default CLI 入口を仕様検討・実装する
+  - 優先度: 最優先。AI agent が `rg` の近くにある道具として短く試せるようにする。
+  - 背景: JSON stdin / stdout は機械処理には有効だが、最初の探索ループでは request JSON を組み立てる負荷が高い。
+  - 実装: `miku-grep QUERY [ROOT]` を追加し、既定では text output とする。
+  - 実装: `--format json` は既存 result JSON を返し、引数なしは従来どおり stdin request JSON を受け取る。
+  - 実装: `--agent`, `--files`, `--context`, `--limit`, `--top-files`, `--encoding`, `--encoding-preset`, `--ignore-case`, `--regex`, `--glob`, `--path`, `--all-targets`, `--detect-git-root`, `--no-ignore` を内部 request shape へ変換する薄い CLI adapter として追加する。
+  - 実装: 表示 mode、query mode、target mode の曖昧な同時指定は parser で明示的に usage error とする。
+  - 関連: `src/main.ts`, `src/help.ts`, `README.md`, `docs/miku-grep-cli-spec.md`
+
 - [x] AI agent 向け検索フロー強化を前向きに仕様検討・実装する
   - 優先度: 最優先候補。`miku-grep` を「検索して終わり」ではなく、「探す」「候補を絞る」「次に読む file を選ぶ」流れまで支える tool として強化する。
   - 前提: 現時点ではユーザー数が少ないため、下方互換性よりも agent が生成しやすい request JSON と読みやすい result JSON を優先してよい。

--- a/docs/miku-grep-cli-spec.md
+++ b/docs/miku-grep-cli-spec.md
@@ -4,7 +4,7 @@
 
 `miku-grep` is a local-first repository search CLI for generative AI agents and automation.
 
-The tool is a grep replacement focused on finding files and snippets that an agent should read next. It returns structured JSON, diagnostics, and summaries instead of human-oriented plain text.
+The tool is a grep replacement focused on finding files and snippets that an agent should read next. Its default argument interface returns human-readable text so agents can try it quickly. It also returns structured JSON, diagnostics, and summaries when `--format json` or stdin request JSON is used.
 
 `miku-grep` is not a semantic retrieve tool. It does not perform embedding
 search or ranking by meaning.
@@ -22,6 +22,8 @@ MVP scope:
 
 - Node CLI
 - `--version`
+- args-first text search
+- `--format json`
 - stdin JSON request
 - stdout JSON result
 - `filepath` / `directory` / `content`
@@ -42,7 +44,25 @@ Out of scope for MVP:
 
 ## CLI Contract
 
-The CLI uses stdin / stdout as its primary interface.
+The CLI has two supported interfaces.
+
+The first interface is args-first and text by default:
+
+```bash
+miku-grep TODO .
+miku-grep TODO . --context 2
+miku-grep TODO . --files
+miku-grep TODO . --agent
+miku-grep TODO . --format json
+miku-grep --files .
+```
+
+When query arguments are provided, stdout contains text unless `--format json`
+is specified. The text format is intended for humans and AI agents in an
+interactive exploration loop. It is stable enough to read, but JSON remains the
+machine contract.
+
+The second interface is stdin request JSON:
 
 ```text
 stdin
@@ -56,9 +76,9 @@ stderr
   progress, verbose logs, unexpected runtime-level messages
 ```
 
-stdout must not contain progress or verbose logs. Agents and scripts should be able to parse stdout as JSON.
+stdout must not contain progress or verbose logs. Agents and scripts should be able to parse stdout as JSON when `--format json` or stdin request JSON is used.
 
-Request validation errors, dangerous requests, decode errors, skips, truncation, and expected search failures are represented in stdout result JSON.
+In JSON mode, request validation errors, dangerous requests, decode errors, skips, truncation, and expected search failures are represented in stdout result JSON.
 
 stdout result JSON should be pretty-printed with 2-space indentation and a trailing newline.
 
@@ -66,7 +86,7 @@ stdout result JSON should be pretty-printed with 2-space indentation and a trail
 JSON.stringify(result, null, 2) + "\n"
 ```
 
-`--version` and `--help` are exceptions to the stdin request JSON contract.
+`--version` and `--help` are metadata commands.
 
 ```bash
 miku-grep --version
@@ -77,8 +97,9 @@ miku-grep --help
 
 `--help` prints a self-contained command description to stdout and exits with code `0`.
 The help output should be detailed enough for an AI agent to understand the
-stdin / stdout contract, request fields, defaults, limits, result shape,
-diagnostics, and examples without reading the full specification.
+short argument interface, stdin / stdout JSON contract, request fields,
+defaults, limits, result shape, diagnostics, and examples without reading the
+full specification.
 
 These commands exist so release assets and Agent Skills can inspect or smoke-test
 a runtime artifact without preparing a request JSON.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "miku-grep",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "miku-grep",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "iconv-lite": "^0.7.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "miku-grep",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Local-first structured grep CLI for AI agents and automation.",
   "license": "Apache-2.0",
   "type": "module",

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,18 +1,100 @@
 export function helpText(): string {
-  return `miku-grep - local-first structured grep CLI for AI agents and automation
+  return `miku-grep - local-first grep CLI for AI agents and automation
 
 USAGE
+  miku-grep QUERY [ROOT]
+  miku-grep QUERY [ROOT] --agent
+  miku-grep QUERY [ROOT] --files
+  miku-grep QUERY [ROOT] --context N
+  miku-grep QUERY [ROOT] --format json
+  miku-grep --files [ROOT]
   miku-grep < request.json > result.json
   miku-grep --version
   miku-grep --help
 
+QUICK EXAMPLES
+  miku-grep TODO .
+  miku-grep TODO . --context 2
+  miku-grep TODO . --files
+  miku-grep TODO . --agent
+  miku-grep TODO . --format json
+  miku-grep TODO . --encoding shift_jis
+  miku-grep --files .
+
+WHEN TO USE
+  Use miku-grep when you would normally reach for rg, but want a small
+  agent-friendly next step:
+    - matching files only:        miku-grep TODO . --files
+    - first readable summary:     miku-grep TODO .
+    - nearby context:             miku-grep TODO . --context 2
+    - next-read candidates:       miku-grep TODO . --agent
+    - machine-readable result:    miku-grep TODO . --format json
+    - legacy Japanese text:       miku-grep 検索語 . --encoding shift_jis
+
 CONTRACT
-  Primary input is stdin JSON. Primary output is stdout JSON.
-  stdout is reserved for result JSON except --version and --help.
+  With QUERY arguments, default output is human-readable text.
+  Use --format json for structured result JSON.
+  With no arguments, stdin JSON is still accepted and stdout is result JSON.
   stderr is for usage errors, malformed stdin, progress, verbose logs, and unexpected runtime messages.
   Request JSON and result JSON use top-level "version": 1.
   Unknown request fields are validation errors.
   Result JSON is pretty-printed with 2-space indentation and a trailing newline.
+
+ARGUMENT OPTIONS
+  --agent
+    Return a compact next-read summary in text mode.
+    In JSON mode, maps to output.mode "agent", relevance sort, and readfile hints.
+
+  --files
+    With QUERY, print matching file paths.
+    Without QUERY, list files under ROOT like an agent-readable rg --files entry point.
+
+  --context N
+    Show N lines of context around content hits. Maps to output.mode "detail".
+
+  --limit N
+    Limit returned matches.
+
+  --top-files N
+    Return agent-oriented top file candidates.
+
+  --format text|json
+    Default for QUERY arguments is text. Use json for machine-readable output.
+
+  --encoding utf-8|shift_jis
+    Decode content with the selected default encoding.
+
+  --encoding-preset japanese-legacy
+    Apply Shift_JIS to common Japanese legacy text file patterns.
+
+  --ignore-case, -i
+    Case-insensitive query.
+
+  --regex
+    Treat QUERY as a regular expression.
+
+  --glob
+    Treat QUERY as a path glob and search file paths.
+
+  --path
+    Search file paths instead of file content.
+
+  --all-targets
+    Search file paths, directory paths, and content.
+
+  --detect-git-root
+    Search upward from ROOT for .git and use that directory as effective root.
+
+  --no-ignore
+    Disable ignore file handling.
+
+OPTION COMBINATIONS
+  --files, --agent/--top-files, and --context are mutually exclusive output modes.
+  --regex and --glob are mutually exclusive query modes.
+  --path and --all-targets are mutually exclusive target modes.
+  --glob implies file path search and cannot be combined with --all-targets.
+  Use miku-grep --files . for inventory.
+  Use miku-grep TODO --files or miku-grep TODO . --files for matching files.
 
 EXIT CODES
   0  ok: true, or explicit meta command such as --version / --help
@@ -321,7 +403,32 @@ COMMON DIAGNOSTIC CODES
     max_snippets_per_file, max_line_chars_exceeded,
     max_files_visited, max_directories_visited
 
-EXAMPLES
+ARGUMENT EXAMPLES
+  Content search:
+    miku-grep TODO .
+
+  Case-insensitive content search:
+    miku-grep repositorymap . --ignore-case
+
+  Matching files only:
+    miku-grep TODO . --files
+
+  File inventory:
+    miku-grep --files .
+
+  Context lines:
+    miku-grep TODO . --context 2
+
+  Agent next-read summary:
+    miku-grep RepositoryMap . --agent
+
+  JSON output:
+    miku-grep TODO . --format json
+
+  Japanese legacy encoding:
+    miku-grep 検索語 . --encoding shift_jis
+
+JSON EXAMPLES
   Content search:
     printf '%s\\n' '{"version":1,"root":".","query":{"type":"literal","text":"TODO"},"search":{"targets":["content"]}}' | miku-grep
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,11 @@ import { runSearch } from "./search.js";
 import { validateAndNormalize } from "./validation.js";
 import type {
   Diagnostic,
+  MikuGrepRequest,
   MikuGrepResult,
   ReadfileRequestHint,
+  SearchTarget,
+  SupportedEncoding,
 } from "./public-types.js";
 
 export { helpText } from "./help.js";
@@ -46,21 +49,31 @@ export type {
 
 export async function main(argv = process.argv, stdin = process.stdin, stdout = process.stdout, stderr = process.stderr): Promise<number> {
   try {
-    if (argv.length === 3 && argv[2] === "--version") {
+    const args = argv.slice(2);
+    if (args.length === 1 && args[0] === "--version") {
       stdout.write(`miku-grep ${await packageVersion()}\n`);
       return 0;
     }
-    if (argv.length === 3 && (argv[2] === "--help" || argv[2] === "-h")) {
+    if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
       stdout.write(helpText());
       return 0;
     }
-    if (argv.length === 3 && argv[2]?.startsWith("-")) {
-      stderr.write("usage: miku-grep [--version|--help]\n");
-      return 2;
-    }
-    if (argv.length > 2) {
-      stderr.write("usage: miku-grep [--version|--help]\n");
-      return 2;
+
+    if (args.length > 0) {
+      const parsed = parseArgs(args);
+      if (!parsed.ok) {
+        stderr.write(`${parsed.message}\nusage: miku-grep QUERY [ROOT] [--agent|--files|--context N|--format json]\n`);
+        return 2;
+      }
+      const result = await runRequest(parsed.request);
+      if (parsed.format === "json") {
+        stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+      } else if (result.ok) {
+        stdout.write(formatTextResult(result, parsed.textMode));
+      } else {
+        stderr.write(formatTextError(result));
+      }
+      return result.ok ? 0 : 1;
     }
 
     let request: unknown;
@@ -78,6 +91,229 @@ export async function main(argv = process.argv, stdin = process.stdin, stdout = 
     stderr.write(`unexpected runtime error: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
     return 3;
   }
+}
+
+type CliTextMode = "summary" | "agent" | "files";
+
+type ParsedArgs =
+  | { ok: true; request: MikuGrepRequest; format: "text" | "json"; textMode: CliTextMode }
+  | { ok: false; message: string };
+
+function parseArgs(args: string[]): ParsedArgs {
+  const positionals: string[] = [];
+  const request: MikuGrepRequest = {
+    version: 1,
+    root: ".",
+    query: { type: "literal", text: "" },
+    search: { targets: ["content"] },
+    output: { mode: "summary" },
+  };
+  let format: "text" | "json" = "text";
+  let textMode: CliTextMode = "summary";
+  let filesMode = false;
+  let filesOptionIndex = -1;
+  let firstPositionalIndex = -1;
+  let agentMode = false;
+  let contextMode = false;
+  let topFilesMode = false;
+  let regexMode = false;
+  let globMode = false;
+  let pathMode = false;
+  let allTargetsMode = false;
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--format") {
+      const value = args[++i];
+      if (value !== "text" && value !== "json") return { ok: false, message: "--format must be text or json" };
+      format = value;
+    } else if (arg === "--json") {
+      format = "json";
+    } else if (arg === "--agent") {
+      request.output = { ...request.output, mode: "agent", sort: "relevance", includeReadfileRequestHints: true };
+      textMode = "agent";
+      agentMode = true;
+    } else if (arg === "--files") {
+      filesMode = true;
+      filesOptionIndex = i;
+      textMode = "files";
+    } else if (arg === "--context") {
+      const value = parseNonNegativeInteger(args[++i], "--context");
+      if (!value.ok) return value;
+      request.output = { ...request.output, mode: "detail", contextLines: value.value };
+      contextMode = true;
+    } else if (arg === "--limit") {
+      const value = parsePositiveInteger(args[++i], "--limit");
+      if (!value.ok) return value;
+      request.output = { ...request.output, maxMatches: value.value };
+    } else if (arg === "--top-files") {
+      const value = parsePositiveInteger(args[++i], "--top-files");
+      if (!value.ok) return value;
+      request.output = { ...request.output, maxMatches: value.value, mode: "agent", sort: "relevance" };
+      textMode = "agent";
+      topFilesMode = true;
+    } else if (arg === "--encoding") {
+      const value = args[++i];
+      if (value !== "utf-8" && value !== "shift_jis") return { ok: false, message: "--encoding must be utf-8 or shift_jis" };
+      request.encoding = { ...request.encoding, default: value as SupportedEncoding };
+    } else if (arg === "--encoding-preset") {
+      const value = args[++i];
+      if (value !== "japanese-legacy") return { ok: false, message: "--encoding-preset must be japanese-legacy" };
+      request.encoding = { ...request.encoding, preset: value };
+    } else if (arg === "--ignore-case" || arg === "-i") {
+      request.query = { type: "literal", text: "", ...request.query, case: "insensitive" };
+    } else if (arg === "--regex") {
+      const currentQuery = request.query ?? { type: "literal", text: "" };
+      request.query = { ...currentQuery, type: "regex" };
+      regexMode = true;
+    } else if (arg === "--glob") {
+      const currentQuery = request.query ?? { type: "literal", text: "" };
+      request.query = { ...currentQuery, type: "glob" };
+      request.search = { ...request.search, targets: ["filepath"] };
+      globMode = true;
+    } else if (arg === "--path") {
+      request.search = { ...request.search, targets: ["filepath"] };
+      pathMode = true;
+    } else if (arg === "--all-targets") {
+      request.search = { ...request.search, targets: ["filepath", "directory", "content"] };
+      allTargetsMode = true;
+    } else if (arg === "--detect-git-root") {
+      request.detectGitRoot = true;
+    } else if (arg === "--no-ignore") {
+      request.ignore = { mode: "none" };
+    } else if (arg.startsWith("-")) {
+      return { ok: false, message: `unknown option: ${arg}` };
+    } else {
+      if (firstPositionalIndex < 0) firstPositionalIndex = i;
+      positionals.push(arg);
+    }
+  }
+
+  const modeConflict = [filesMode, agentMode || topFilesMode, contextMode].filter(Boolean).length > 1;
+  if (modeConflict) return { ok: false, message: "--files, --agent/--top-files, and --context are mutually exclusive" };
+  if (regexMode && globMode) return { ok: false, message: "--regex and --glob are mutually exclusive" };
+  if (pathMode && allTargetsMode) return { ok: false, message: "--path and --all-targets are mutually exclusive" };
+  if (globMode && allTargetsMode) return { ok: false, message: "--glob and --all-targets are mutually exclusive" };
+
+  const filesInventoryMode = filesMode && (positionals.length === 0 || (positionals.length === 1 && filesOptionIndex >= 0 && filesOptionIndex < firstPositionalIndex));
+  if (filesInventoryMode) {
+    delete request.query;
+    request.mode = "listFiles";
+    request.root = positionals[0] ?? ".";
+    return { ok: true, request, format, textMode };
+  }
+
+  if (positionals.length < 1 || positionals.length > 2) {
+    return { ok: false, message: "expected QUERY [ROOT]" };
+  }
+
+  request.query = { type: "literal", case: "sensitive", ...request.query, text: positionals[0] };
+  request.root = positionals[1] ?? ".";
+  if (filesMode) {
+    request.output = { ...request.output, mode: "summary" };
+    request.search = { ...request.search, targets: ensureFileTargets(request.search?.targets) };
+  }
+  return { ok: true, request, format, textMode };
+}
+
+function parsePositiveInteger(value: string | undefined, option: string): { ok: true; value: number } | { ok: false; message: string } {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) return { ok: false, message: `${option} requires a positive integer` };
+  return { ok: true, value: parsed };
+}
+
+function parseNonNegativeInteger(value: string | undefined, option: string): { ok: true; value: number } | { ok: false; message: string } {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) return { ok: false, message: `${option} requires a non-negative integer` };
+  return { ok: true, value: parsed };
+}
+
+function ensureFileTargets(targets: SearchTarget[] | undefined): SearchTarget[] {
+  if (!targets || targets.length === 0) return ["content"];
+  return targets.filter((target) => target !== "directory");
+}
+
+function formatTextResult(result: MikuGrepResult, mode: CliTextMode): string {
+  if (mode === "files") return formatFilesText(result);
+  if (mode === "agent") return formatAgentText(result);
+  if (result.effectiveRequest.mode === "listFiles") return formatFilesText(result);
+  return formatSummaryText(result);
+}
+
+function formatFilesText(result: MikuGrepResult): string {
+  const files = result.files && result.files.length > 0 ? result.files.map((file) => file.path) : uniqueFiles(result);
+  return files.length > 0 ? `${files.join("\n")}\n` : "";
+}
+
+function formatSummaryText(result: MikuGrepResult): string {
+  const lines = [
+    `matches: ${result.summary.matches}`,
+    `files: ${result.summary.filesMatched}`,
+  ];
+  if (result.summary.directoriesMatched > 0) lines.push(`directories: ${result.summary.directoriesMatched}`);
+  if (result.summary.truncated) lines.push(`truncated: ${result.summary.truncatedReason ?? "true"}`);
+  if (result.diagnostics.length > 0) lines.push(`diagnostics: ${result.diagnostics.length}`);
+  lines.push("");
+
+  for (const match of result.matches.slice(0, 20)) {
+    if (match.type === "file") {
+      lines.push(`${match.file}  ${match.matchCount} match${match.matchCount === 1 ? "" : "es"}`);
+      for (const snippet of match.snippets.slice(0, 3)) lines.push(`  ${snippet.line}: ${snippet.text}`);
+    } else if (match.type === "content") {
+      lines.push(`${match.file}:${match.line}:${match.column}: ${match.text}`);
+      for (const context of match.contextBefore ?? []) lines.push(`  ${context.line}- ${context.text}`);
+      for (const context of match.contextAfter ?? []) lines.push(`  ${context.line}+ ${context.text}`);
+    } else if (match.type === "filepath") {
+      lines.push(match.file);
+    } else if (match.type === "directory") {
+      lines.push(`${match.path}/`);
+    } else if (match.type === "agentFile") {
+      lines.push(`${match.file}  ${match.matchCount} match${match.matchCount === 1 ? "" : "es"}`);
+    } else if (match.type === "agentDirectory") {
+      lines.push(`${match.path}/  ${match.matchCount} match${match.matchCount === 1 ? "" : "es"}`);
+    }
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function formatAgentText(result: MikuGrepResult): string {
+  const lines = [
+    `matches: ${result.summary.matches}`,
+    `files: ${result.summary.filesMatched}`,
+  ];
+  if (result.summary.truncated) lines.push(`truncated: ${result.summary.truncatedReason ?? "true"}`);
+  lines.push("", "top files:");
+
+  const agentFiles = result.matches.filter((match) => match.type === "agentFile");
+  for (const match of agentFiles.slice(0, 10)) {
+    if (match.type !== "agentFile") continue;
+    lines.push(`  ${match.file}  ${match.matchCount} match${match.matchCount === 1 ? "" : "es"}`);
+    for (const snippet of match.representativeSnippets.slice(0, 2)) lines.push(`    ${snippet.line}: ${snippet.text}`);
+  }
+
+  const readRanges = agentFiles
+    .flatMap((match) => (match.type === "agentFile" ? match.readRanges.slice(0, 1).map((range) => `${match.file}:${range.startLine}-${range.endLine}`) : []))
+    .slice(0, 10);
+  if (readRanges.length > 0) {
+    lines.push("", "next reads:");
+    for (const range of readRanges) lines.push(`  ${range}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+function formatTextError(result: MikuGrepResult): string {
+  const error = result.error;
+  const lines = [`error: ${error?.code ?? "unknown"}${error?.message ? `: ${error.message}` : ""}`];
+  for (const diagnostic of result.diagnostics.slice(0, 5)) lines.push(`${diagnostic.severity}: ${diagnostic.code}: ${diagnostic.message}`);
+  return `${lines.join("\n")}\n`;
+}
+
+function uniqueFiles(result: MikuGrepResult): string[] {
+  const files = new Set<string>();
+  for (const match of result.matches) {
+    if (match.type === "file" || match.type === "filepath" || match.type === "content" || match.type === "agentFile") files.add(match.file);
+  }
+  return [...files].sort();
 }
 
 export async function runRequest(request: unknown): Promise<MikuGrepResult> {

--- a/test/cli-meta.test.ts
+++ b/test/cli-meta.test.ts
@@ -9,6 +9,12 @@ describe("miku-grep CLI meta and stdio contract", () => {
     const text = helpText();
 
     expect(text).toContain("USAGE");
+    expect(text).toContain("QUICK EXAMPLES");
+    expect(text).toContain("miku-grep TODO .");
+    expect(text).toContain("WHEN TO USE");
+    expect(text).toContain("ARGUMENT OPTIONS");
+    expect(text).toContain("ARGUMENT EXAMPLES");
+    expect(text).toContain("JSON EXAMPLES");
     expect(text).toContain("MINIMAL REQUEST");
     expect(text).toContain("REQUEST FIELDS");
     expect(text).toContain("RESULT SHAPE");
@@ -29,8 +35,65 @@ describe("miku-grep CLI meta and stdio contract", () => {
 
     expect(code).toBe(0);
     expect(stderr.output()).toBe("");
-    expect(stdout.output()).toContain("miku-grep - local-first structured grep CLI");
+    expect(stdout.output()).toContain("miku-grep - local-first grep CLI");
+    expect(stdout.output()).toContain("QUICK EXAMPLES");
     expect(stdout.output()).toContain("MINIMAL REQUEST");
+  });
+
+  test("main returns text output for args-first search by default", async () => {
+    const root = await fixture();
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(["node", "miku-grep", "RepositoryMap", root], Readable.from([]), stdout.stream, stderr.stream);
+
+    expect(code).toBe(0);
+    expect(stderr.output()).toBe("");
+    expect(stdout.output()).toContain("matches:");
+    expect(stdout.output()).toContain("README.md");
+    expect(() => JSON.parse(stdout.output())).toThrow();
+  });
+
+  test("main returns JSON output for args-first search with --format json", async () => {
+    const root = await fixture();
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(["node", "miku-grep", "RepositoryMap", root, "--format", "json"], Readable.from([]), stdout.stream, stderr.stream);
+
+    expect(code).toBe(0);
+    expect(stderr.output()).toBe("");
+    expect(JSON.parse(stdout.output())).toMatchObject({ version: 1, ok: true });
+  });
+
+  test("main prints matching file paths for args-first --files", async () => {
+    const root = await fixture();
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(["node", "miku-grep", "RepositoryMap", root, "--files"], Readable.from([]), stdout.stream, stderr.stream);
+
+    expect(code).toBe(0);
+    expect(stderr.output()).toBe("");
+    expect(stdout.output().split("\n")).toEqual(expect.arrayContaining(["README.md", "src/RepositoryMap.java"]));
+  });
+
+  test("main treats QUERY --files as matching files in the current root", async () => {
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(["node", "miku-grep", "RepositoryMap", "--files"], Readable.from([]), stdout.stream, stderr.stream);
+
+    expect(code).toBe(0);
+    expect(stderr.output()).toBe("");
+    expect(stdout.output()).toContain("README.md");
+  });
+
+  test("main lists inventory for --files without query", async () => {
+    const root = await fixture();
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(["node", "miku-grep", "--files", root], Readable.from([]), stdout.stream, stderr.stream);
+
+    expect(code).toBe(0);
+    expect(stderr.output()).toBe("");
+    expect(stdout.output().split("\n")).toEqual(expect.arrayContaining(["README.md", "src/RepositoryMap.java", "src/legacy.txt"]));
   });
 
   test("main returns exit 0 and stdout JSON for valid requests", async () => {
@@ -86,7 +149,37 @@ describe("miku-grep CLI meta and stdio contract", () => {
 
     expect(code).toBe(2);
     expect(stdout.output()).toBe("");
-    expect(stderr.output()).toContain("usage: miku-grep [--version|--help]");
+    expect(stderr.output()).toContain("usage: miku-grep QUERY [ROOT]");
+  });
+
+  test("main rejects mutually exclusive args-first output modes", async () => {
+    const root = await fixture();
+    const stdout = writableCapture();
+    const stderr = writableCapture();
+    const code = await main(["node", "miku-grep", "RepositoryMap", root, "--agent", "--context", "2"], Readable.from([]), stdout.stream, stderr.stream);
+
+    expect(code).toBe(2);
+    expect(stdout.output()).toBe("");
+    expect(stderr.output()).toContain("mutually exclusive");
+  });
+
+  test("main rejects mutually exclusive args-first query and target modes", async () => {
+    const root = await fixture();
+    const regexGlobStdout = writableCapture();
+    const regexGlobStderr = writableCapture();
+    const regexGlobCode = await main(["node", "miku-grep", "RepositoryMap", root, "--regex", "--glob"], Readable.from([]), regexGlobStdout.stream, regexGlobStderr.stream);
+
+    expect(regexGlobCode).toBe(2);
+    expect(regexGlobStdout.output()).toBe("");
+    expect(regexGlobStderr.output()).toContain("--regex and --glob are mutually exclusive");
+
+    const pathAllStdout = writableCapture();
+    const pathAllStderr = writableCapture();
+    const pathAllCode = await main(["node", "miku-grep", "RepositoryMap", root, "--path", "--all-targets"], Readable.from([]), pathAllStdout.stream, pathAllStderr.stream);
+
+    expect(pathAllCode).toBe(2);
+    expect(pathAllStdout.output()).toBe("");
+    expect(pathAllStderr.output()).toContain("--path and --all-targets are mutually exclusive");
   });
 
   test("dist CLI process returns exit 0 with parseable stdout JSON", async () => {


### PR DESCRIPTION
## 概要

`miku-grep` に `miku-grep QUERY [ROOT]` 形式の短い引数入口を追加し、既定出力を text にしました。従来の stdin request JSON 入口は維持しつつ、`--format json` で既存の structured JSON result も返せるようにしています。

## 変更内容

- `src/main.ts` に args-first CLI parser を追加
- `--agent`, `--files`, `--context`, `--limit`, `--top-files`, `--encoding`, `--encoding-preset`, `--ignore-case`, `--regex`, `--glob`, `--path`, `--all-targets`, `--detect-git-root`, `--no-ignore` を内部 request shape へ変換
- text 出力として summary、agent、files 表示を追加
- `--files` 単体で file inventory を出せるように対応
- 出力 mode、query mode、target mode の競合指定を usage error として扱うように追加
- `--help`、README、CLI spec に args-first CLI の使い方と例を追記
- args-first CLI、JSON 出力、`--files`、競合 option のテストを追加
- package version を `0.10.0` に更新